### PR TITLE
Fix EAN overflow in backend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -37,24 +37,30 @@ def create_app():
         df = pd.read_excel(file)
         count = 0
         for _, row in df.iterrows():
+            # Cast EAN to string to keep the exact value regardless of
+            # how pandas interpreted the column (float, int, etc.).
+            ean_value = None
+            if pd.notnull(row.get('ean')):
+                # remove any decimal part introduced by Excel or pandas
+                ean_value = str(int(row.get('ean')))
             temp = TempImport(
                 description=row.get('description'),
                 articlelno=row.get('articlelno', None),
                 quantity=row.get('quantity', None),
                 selling_prince=row.get('selling_prince', None),
-                ean=row.get('ean')
+                ean=ean_value
             )
             db.session.add(temp)
 
             # Create reference if it does not already exist
-            ref = Reference.query.filter_by(ean=row.get('ean')).first()
+            ref = Reference.query.filter_by(ean=ean_value).first()
             if not ref:
                 ref = Reference(
                     name=row.get('description'),
                     articlelno=row.get('articlelno', None),
                     quantity=row.get('quantity', None),
                     selling_prince=row.get('selling_prince', None),
-                    ean=row.get('ean')
+                    ean=ean_value
                 )
                 db.session.add(ref)
             count += 1

--- a/backend/create_tables.py
+++ b/backend/create_tables.py
@@ -17,7 +17,8 @@ CREATE TABLE IF NOT EXISTS temp_imports (
     articlelno VARCHAR(50),
     quantity INTEGER,
     selling_prince FLOAT,
-    ean FLOAT UNIQUE NOT NULL
+    -- store EAN codes as text to avoid integer overflow
+    ean VARCHAR(20) UNIQUE NOT NULL
 );
 """)
 
@@ -28,7 +29,8 @@ CREATE TABLE IF NOT EXISTS reference (
     articlelno VARCHAR(50),
     quantity INTEGER,
     selling_prince FLOAT,
-    ean FLOAT UNIQUE NOT NULL
+    -- same here, use text for EAN codes
+    ean VARCHAR(20) UNIQUE NOT NULL
 );
 """)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -10,7 +10,10 @@ class TempImport(db.Model):
     articlelno = db.Column(db.String(50))
     quantity = db.Column(db.Integer)
     selling_prince = db.Column(db.Float)
-    ean = db.Column(db.Float, unique=True, nullable=False)
+    # EAN codes can exceed the range of a 32 bit integer and may contain
+    # leading zeros. Store them as strings to avoid numeric overflow and
+    # preserve the exact value.
+    ean = db.Column(db.String(20), unique=True, nullable=False)
 
 class Reference(db.Model):
     __tablename__ = 'references'
@@ -20,7 +23,9 @@ class Reference(db.Model):
     articlelno = db.Column(db.String(50))
     quantity = db.Column(db.Float)
     selling_prince = db.Column(db.Float)
-    ean = db.Column(db.Integer, unique=True, nullable=False)
+    # Same reasoning as in ``TempImport``: keep the original code without
+    # risking integer overflows.
+    ean = db.Column(db.String(20), unique=True, nullable=False)
 
 class Product(db.Model):
     __tablename__ = 'products'


### PR DESCRIPTION
## Summary
- store EAN columns as strings in SQLAlchemy models
- update table creation script to use VARCHAR type for EAN codes
- cast EAN values from Excel to string in the import endpoint

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686be59ce9cc83279689c840073bbb21