### PR TITLE
Store product calculations

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -34,16 +34,13 @@ export async function createProduct() {
   return res.json();
 }
 
-// export async function uploadExcel(file: File) {
-//   const formData = new FormData();
-//   formData.append('file', file);
-
-//   const res = await fetch(`${API_BASE}/upload`, {
-//     method: 'POST',
-//     body: formData
-//   });
-//   if (!res.ok) {
-//     throw new Error("Erreur lors de l'upload du fichier");
-//   }
-//   return res.json();
-// }
+export async function calculateProducts() {
+  const res = await fetch(`${API_BASE}/calculate_products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    throw new Error('Erreur lors du calcul des produits');
+  }
+  return res.json();
+}

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { FileUp, FileDown, ArrowRight, Loader2, Download, ChevronRight } from 'lucide-react';
 import * as XLSX from 'xlsx';
-import { createProduct, fetchProducts, createImport } from '../api';
+import { createProduct, fetchProducts, createImport, calculateProducts } from '../api';
 import {
   sanitizeName,
   isExcludedProduct,
@@ -165,6 +165,7 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
       // Importer les références puis envoyer le fichier original au backend
       await createImport(file);
       await createProduct();
+      await calculateProducts();
       const list = await fetchProducts();
       setProductsCount(list.length);
     } catch (error) {


### PR DESCRIPTION
## Summary
- compute TCP and margin in backend and store in `product_calculates`
- expose new `/calculate_products` API endpoint
- call this new endpoint from the processing flow
- remove obsolete commented code

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cb720c3548327b2c1d521246ae907