### PR TITLE
Use env variables for backend settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://username:password@localhost:5432/ajtpro
+FRONTEND_URL=http://localhost:5173
+VITE_API_BASE=http://localhost:5001
+FLASK_HOST=0.0.0.0
+PORT=5001

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Créez un fichier `.env` à la racine du projet avec vos identifiants Supabase :
 ```bash
 VITE_SUPABASE_URL=<votre_url_supabase>
 VITE_SUPABASE_ANON_KEY=<votre_cle_anon>
+VITE_API_BASE=http://localhost:5001
 ```
 
 Ce fichier est ignoré par Git afin de protéger vos informations sensibles.
@@ -128,8 +129,12 @@ Un backend minimal en **Python** est fourni dans le dossier `backend`. Il utilis
 make db-create    # crée la base `ajtpro` si besoin
 
 make venv         # crée l'environnement virtuel et installe les dépendances
-# Créez un fichier `.env` contenant l'URL de connexion :
-# DATABASE_URL=postgresql://postgres:postgres@localhost:5432/ajtpro
+# Créez un fichier `.env` contenant vos variables :
+# DATABASE_URL=postgresql://user:password@host:5432/ajtpro
+# FRONTEND_URL=http://votre-site.com
+# VITE_API_BASE=http://votre-backend:5001
+# FLASK_HOST=0.0.0.0
+# PORT=5001
 # Un fichier `.env.example` est fourni à titre d'exemple.
 make run          # démarre l'API Flask
 ```

--- a/backend/app.py
+++ b/backend/app.py
@@ -23,18 +23,20 @@ from datetime import datetime, timezone
 
 def create_app():
     # Load environment variables from a local .env file if present
-    load_dotenv()
+    env_path = os.path.join(os.path.dirname(__file__), '..', '.env')
+    load_dotenv(env_path)
 
     app = Flask(__name__)
-    CORS(app, resources={r"/*": {"origins": "http://localhost:5173"}})
+
+    frontend_origin = os.getenv("FRONTEND_URL", "http://localhost:5173")
+    CORS(app, resources={r"/*": {"origins": frontend_origin}})
 
     @app.route('/')
     def index():
         return {'message': 'Hello World'}
-    database_url = os.environ.get(
-        "DATABASE_URL",
-        "postgresql://eloise@localhost:5432/ajtpro"
-    )
+    database_url = os.getenv("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL environment variable is not set")
     app.config['SQLALCHEMY_DATABASE_URI'] = database_url
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     db.init_app(app)
@@ -316,5 +318,7 @@ def create_app():
 
 if __name__ == '__main__':
     app = create_app()
-    app.run(debug=True, port=5001)
+    host = os.getenv("FLASK_HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "5001"))
+    app.run(host=host, port=port)
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-export const API_BASE = 'http://localhost:5001';
+export const API_BASE = import.meta.env.VITE_API_BASE || '';
 
 
 export async function createImport(file: File, supplierId?: number) {


### PR DESCRIPTION
## Summary
- load variables from `.env`
- allow CORS origin via environment variable
- use env vars for DB connection
- configure host/port via env variables
- use VITE_API_BASE in frontend API
- document env vars
- add `.env.example`

## Testing
- `python3 -m py_compile backend/app.py backend/models.py backend/create_tables.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_686d241d6d148327bced172b02aa12d8