### PR TITLE
Fix export filename and document lint/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ L'application expose notamment les routes :
 - `POST /upload` : envoi d'un fichier Excel pour importer plusieurs produits.
 - `POST /import` : importe un fichier Excel dans `temp_imports` et crée les références
   correspondantes.
+- `GET /product_calculations/count` : renvoie le nombre de résultats de calcul disponibles.
 
 Dans l'application React, le fichier traité est automatiquement transmis au backend via l'endpoint `/upload`. L'import du référentiel utilise quant à lui l'endpoint `/import`.
 

--- a/README.md
+++ b/README.md
@@ -152,3 +152,15 @@ L'application expose notamment les routes :
 
 Dans l'application React, le fichier traité est automatiquement transmis au backend via l'endpoint `/upload`. L'import du référentiel utilise quant à lui l'endpoint `/import`.
 
+## Vérifications locales
+
+Le projet fournit quelques commandes pour garder une base de code cohérente.
+
+### Lint
+
+Exécutez `npm run lint` après avoir installé les dépendances de développement (`npm install`). Sans ces packages, la commande peut échouer.
+
+### Tests Python
+
+Il n'existe pas encore de tests automatisés mais `pytest` est configuré pour unifier la procédure. Lancez simplement `pytest` pour vérifier qu'aucune erreur n'est remontée.
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -31,7 +31,7 @@ def create_app():
     frontend_origin = os.getenv("FRONTEND_URL")
     if not frontend_origin:
         raise RuntimeError("FRONTEND_URL environment variable is not set")
-    CORS(app, resources={r"/*": {"origins": frontend_origin}})
+    CORS(app, resources={r"/*": {"origins": frontend_origin}}, expose_headers=["Content-Disposition"])
 
     @app.route('/')
     def index():

--- a/backend/app.py
+++ b/backend/app.py
@@ -164,6 +164,11 @@ def create_app():
         ]
         return jsonify(result)
 
+    @app.route('/product_calculations/count', methods=['GET'])
+    def count_product_calculations():
+        count = ProductCalculation.query.count()
+        return jsonify({'count': count})
+
     @app.route('/populate_products', methods=['POST'])
     def populate_products_from_reference():
         references = ProductReference.query.all()

--- a/src/api.ts
+++ b/src/api.ts
@@ -67,6 +67,15 @@ export async function exportCalculations() {
   return { blob, filename };
 }
 
+export async function fetchCalculationCount(): Promise<number> {
+  const res = await fetch(`${API_BASE}/product_calculations/count`);
+  if (!res.ok) {
+    throw new Error('Erreur lors du chargement des calculs');
+  }
+  const data = await res.json();
+  return data.count as number;
+}
+
 
 export async function fetchSuppliers() {
   const res = await fetch(`${API_BASE}/suppliers`);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,5 @@
+import { getCurrentTimestamp } from './utils/date';
+
 export const API_BASE = import.meta.env.VITE_API_BASE || '';
 
 
@@ -54,7 +56,7 @@ export async function exportCalculations() {
     throw new Error('Erreur lors de la génération du fichier');
   }
   const blob = await res.blob();
-  let filename = 'export.xlsx';
+  let filename = `product_calculates_${getCurrentTimestamp()}.xlsx`;
   const disposition = res.headers.get('Content-Disposition');
   if (disposition) {
     const match = disposition.match(/filename="?([^";]+)"?/);

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -15,7 +15,7 @@ import {
   exportCalculations,
   fetchSuppliers,
 } from '../api';
-import { getCurrentWeekYear } from '../utils/date';
+import { getCurrentWeekYear, getCurrentTimestamp } from '../utils/date';
 
 interface ProcessingPageProps {
   onNext: () => void;
@@ -215,7 +215,9 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
               onClick={() => {
                 const link = document.createElement('a');
                 link.href = processedFile;
-                link.download = processedFileName || 'product_calculates.xlsx';
+                link.download =
+                  processedFileName ||
+                  `product_calculates_${getCurrentTimestamp()}.xlsx`;
                 document.body.appendChild(link);
                 link.click();
                 document.body.removeChild(link);

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -14,6 +14,7 @@ import {
   calculateProducts,
   exportCalculations,
   fetchSuppliers,
+  fetchCalculationCount,
 } from '../api';
 import { getCurrentWeekYear, getCurrentTimestamp } from '../utils/date';
 
@@ -112,6 +113,7 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
   const [processedFile, setProcessedFile] = useState<string | null>(null);
   const [processedFileName, setProcessedFileName] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
+  const [hasCalculations, setHasCalculations] = useState(false);
 
   const refreshCount = useCallback(async () => {
     const list = await fetchProducts();
@@ -146,6 +148,7 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
       const { blob, filename } = await exportCalculations();
       setProcessedFile(URL.createObjectURL(blob));
       setProcessedFileName(filename);
+      setHasCalculations(true);
     } catch (err) {
       console.error('Error processing files:', err);
       setError(
@@ -164,6 +167,9 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
     fetchSuppliers()
       .then(setSuppliers)
       .catch(() => {});
+    fetchCalculationCount()
+      .then((c) => setHasCalculations(c > 0))
+      .catch(() => setHasCalculations(false));
   }, [refreshCount]);
 
   return (
@@ -210,24 +216,26 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
         )}
 
         <div className="space-y-4 flex flex-col items-center">
-          <button
-            onClick={() => {
-              if (!processedFile) return;
-              const link = document.createElement('a');
-              link.href = processedFile;
-              link.download =
-                processedFileName ||
-                `product_calculates_${getCurrentTimestamp()}.xlsx`;
-              document.body.appendChild(link);
-              link.click();
-              document.body.removeChild(link);
-            }}
-            disabled={!processedFile}
-            className="px-6 py-3 bg-[#B8860B] text-black rounded-lg flex items-center space-x-2 hover:bg-[#B8860B]/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-semibold"
-          >
-            <Download className="w-5 h-5" />
-            <span>Télécharger</span>
-          </button>
+          {hasCalculations && (
+            <button
+              onClick={() => {
+                if (!processedFile) return;
+                const link = document.createElement('a');
+                link.href = processedFile;
+                link.download =
+                  processedFileName ||
+                  `product_calculates_${getCurrentTimestamp()}.xlsx`;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+              }}
+              disabled={!processedFile}
+              className="px-6 py-3 bg-[#B8860B] text-black rounded-lg flex items-center space-x-2 hover:bg-[#B8860B]/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-semibold"
+            >
+              <Download className="w-5 h-5" />
+              <span>Télécharger</span>
+            </button>
+          )}
 
           {processedFile && (
             <button

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -209,25 +209,27 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
           </div>
         )}
 
-        {processedFile && (
-          <div className="space-y-4 flex flex-col items-center">
-            <button
-              onClick={() => {
-                const link = document.createElement('a');
-                link.href = processedFile;
-                link.download =
-                  processedFileName ||
-                  `product_calculates_${getCurrentTimestamp()}.xlsx`;
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-              }}
-              className="px-6 py-3 bg-[#B8860B] text-black rounded-lg flex items-center space-x-2 hover:bg-[#B8860B]/90 transition-colors font-semibold"
-            >
-              <Download className="w-5 h-5" />
-              <span>Télécharger</span>
-            </button>
+        <div className="space-y-4 flex flex-col items-center">
+          <button
+            onClick={() => {
+              if (!processedFile) return;
+              const link = document.createElement('a');
+              link.href = processedFile;
+              link.download =
+                processedFileName ||
+                `product_calculates_${getCurrentTimestamp()}.xlsx`;
+              document.body.appendChild(link);
+              link.click();
+              document.body.removeChild(link);
+            }}
+            disabled={!processedFile}
+            className="px-6 py-3 bg-[#B8860B] text-black rounded-lg flex items-center space-x-2 hover:bg-[#B8860B]/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-semibold"
+          >
+            <Download className="w-5 h-5" />
+            <span>Télécharger</span>
+          </button>
 
+          {processedFile && (
             <button
               onClick={onNext}
               className="px-8 py-4 bg-green-600 text-white rounded-lg flex items-center space-x-2 hover:bg-green-700 transition-colors font-semibold text-lg"
@@ -235,8 +237,8 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
               <span>Passer à l'étape 2 - Mise en forme</span>
               <ChevronRight className="w-6 h-6" />
             </button>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       <div className="mt-8 text-center text-sm text-zinc-500">

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -14,7 +14,6 @@ import {
   calculateProducts,
   exportCalculations,
   fetchSuppliers,
-  fetchCalculationCount,
 } from '../api';
 import { getCurrentWeekYear, getCurrentTimestamp } from '../utils/date';
 
@@ -113,7 +112,6 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
   const [processedFile, setProcessedFile] = useState<string | null>(null);
   const [processedFileName, setProcessedFileName] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
-  const [hasCalculations, setHasCalculations] = useState(false);
 
   const refreshCount = useCallback(async () => {
     const list = await fetchProducts();
@@ -148,7 +146,6 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
       const { blob, filename } = await exportCalculations();
       setProcessedFile(URL.createObjectURL(blob));
       setProcessedFileName(filename);
-      setHasCalculations(true);
     } catch (err) {
       console.error('Error processing files:', err);
       setError(
@@ -167,16 +164,31 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
     fetchSuppliers()
       .then(setSuppliers)
       .catch(() => {});
-    fetchCalculationCount()
-      .then((c) => setHasCalculations(c > 0))
-      .catch(() => setHasCalculations(false));
   }, [refreshCount]);
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-12">
       <h1 className="text-4xl font-bold text-center mb-2">Étape 1 - Calculs et Traitement</h1>
       <p className="text-center text-[#B8860B] mb-4">Traitez vos fichiers Excel avec calculs TCP et marges</p>
-      <p className="text-center text-zinc-400 mb-12">Semaine {getCurrentWeekYear()}</p>
+      <p className="text-center text-zinc-400 mb-4">Semaine {getCurrentWeekYear()}</p>
+      <div className="flex justify-center mb-8">
+        <button
+          onClick={() => {
+            if (!processedFile) return;
+            const link = document.createElement('a');
+            link.href = processedFile;
+            link.download =
+              processedFileName || `product_calculates_${getCurrentTimestamp()}.xlsx`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+          }}
+          className="px-6 py-3 bg-[#B8860B] text-black rounded-lg flex items-center space-x-2 hover:bg-[#B8860B]/90 transition-colors font-semibold"
+        >
+          <Download className="w-5 h-5" />
+          <span>Télécharger</span>
+        </button>
+      </div>
       <p className="text-center text-sm text-zinc-500 mb-8">Produits en base : {productsCount}</p>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -216,27 +228,6 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
         )}
 
         <div className="space-y-4 flex flex-col items-center">
-          {hasCalculations && (
-            <button
-              onClick={() => {
-                if (!processedFile) return;
-                const link = document.createElement('a');
-                link.href = processedFile;
-                link.download =
-                  processedFileName ||
-                  `product_calculates_${getCurrentTimestamp()}.xlsx`;
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-              }}
-              disabled={!processedFile}
-              className="px-6 py-3 bg-[#B8860B] text-black rounded-lg flex items-center space-x-2 hover:bg-[#B8860B]/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-semibold"
-            >
-              <Download className="w-5 h-5" />
-              <span>Télécharger</span>
-            </button>
-          )}
-
           {processedFile && (
             <button
               onClick={onNext}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -6,3 +6,15 @@ export function getCurrentWeekYear(): string {
   const weekNumber = Math.ceil((pastDays + startOfYear.getDay() + 1) / 7);
   return `S${weekNumber}-${year}`;
 }
+
+export function getCurrentTimestamp(): string {
+  const now = new Date();
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  const year = now.getFullYear();
+  const month = pad(now.getMonth() + 1);
+  const day = pad(now.getDate());
+  const hours = pad(now.getHours());
+  const minutes = pad(now.getMinutes());
+  const seconds = pad(now.getSeconds());
+  return `${year}${month}${day}_${hours}${minutes}${seconds}`;
+}


### PR DESCRIPTION
## Summary
- expose `Content-Disposition` header so the frontend can read it
- add a `getCurrentTimestamp` helper
- timestamp default filename in the API and download button
- document lint and test usage in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e80ce45548327a3ba11620280cb81