### PR TITLE
Display supplier last import date

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -164,20 +164,24 @@ def create_app():
         ]
         return jsonify(result)
 
-    @app.route('/supplier_last_import/{id}', methods=['GET'])
-    def supplier_last_import(id):
-        histories = ImportHistory.query.filter_by(supplier_id=id).order_by(ImportHistory.import_date.desc()).first()
-        result = [
-            {
-                'id': h.id,
-                'filename': h.filename,
-                'supplier_id': h.supplier_id,
-                'product_count': h.product_count,
-                'import_date': h.import_date.isoformat(),
-            }
-            for h in histories
-        ]
-        return jsonify(result)
+    @app.route('/last_import/<int:supplier_id>', methods=['GET'])
+    def last_import(supplier_id):
+        history = (
+            ImportHistory.query
+            .filter_by(supplier_id=supplier_id)
+            .order_by(ImportHistory.import_date.desc())
+            .first()
+        )
+        if not history:
+            return jsonify({}), 200
+
+        return jsonify({
+            'id': history.id,
+            'filename': history.filename,
+            'supplier_id': history.supplier_id,
+            'product_count': history.product_count,
+            'import_date': history.import_date.isoformat(),
+        })
 
     @app.route('/product_calculations/count', methods=['GET'])
     def count_product_calculations():

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,10 +29,10 @@ export async function fetchProducts() {
 }
 
 
-export async function fetchImport(id: number = 0) {
-  const res = await fetch(`${API_BASE}/supplier_last_import/${id} `);
+export async function fetchLastImport(id: number): Promise<{ import_date: string | null } | {}> {
+  const res = await fetch(`${API_BASE}/last_import/${id}`);
   if (!res.ok) {
-    throw new Error('Erreur lors du chargement des produits');
+    throw new Error('Erreur lors du chargement de la date d\'import');
   }
   return res.json();
 }

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -16,7 +16,7 @@ import {
   fetchSuppliers,
   fetchLastImport,
 } from '../api';
-import { getCurrentWeekYear, getCurrentTimestamp } from '../utils/date';
+import { getCurrentWeekYear, getCurrentTimestamp,getWeekYear } from '../utils/date';
 
 interface ProcessingPageProps {
   onNext: () => void;
@@ -28,11 +28,6 @@ interface Supplier {
   email?: string;
   phone?: string;
   address?: string;
-}
-
-interface Import {
-  import_date: string;
-  supplier_id: number;
 }
 
 interface ImportZoneProps {
@@ -85,7 +80,15 @@ function ImportZone({ supplier, file, lastImportDate, onFileChange }: ImportZone
     <div className="bg-zinc-900 rounded-2xl shadow-2xl p-8 border border-[#B8860B]/20">
       <h2 className="text-xl font-semibold mb-6">Import de {supplier.name}</h2>
       {lastImportDate && (
-        <p className="text-sm text-zinc-400 mb-2">Dernier import : {new Date(lastImportDate).toLocaleString()}</p>
+        <p className="text-sm text-zinc-400 mb-2">
+          Dernier import : {getWeekYear(new Date (lastImportDate))} -{' '}
+          {new Date(lastImportDate).toLocaleDateString('fr-FR', 
+          {
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+          }
+        )} </p>
       )}
       <div
         className={`border-2 border-dashed rounded-xl p-8 transition-all duration-200 ${
@@ -204,7 +207,7 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
     <div className="max-w-4xl mx-auto px-4 py-12">
       <h1 className="text-4xl font-bold text-center mb-2">Étape 1 - Calculs et Traitement</h1>
       <p className="text-center text-[#B8860B] mb-4">Traitez vos fichiers Excel avec calculs TCP et marges</p>
-      <p className="text-center text-zinc-400 mb-4">Semaine en cours {getCurrentWeekYear()}</p>
+      <p className="text-center text-zinc-400 mb-4">Semaine en cours : {getCurrentWeekYear()}</p>
       <div className="flex justify-center mb-8">
         <button
           onClick={() => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -18,3 +18,12 @@ export function getCurrentTimestamp(): string {
   const seconds = pad(now.getSeconds());
   return `${year}${month}${day}_${hours}${minutes}${seconds}`;
 }
+
+export function getWeekYear(today: Date): string {
+  const date = new Date(today);
+  const year = date.getFullYear();
+  const startOfYear = new Date(year, 0, 1);
+  const pastDays = (date.getTime() - startOfYear.getTime()) / 86400000;
+  const weekNumber = Math.ceil((pastDays + startOfYear.getDay() + 1) / 7);
+  return `S${weekNumber}-${year}`;
+}


### PR DESCRIPTION
## Summary
- add new `/last_import/<int:supplier_id>` endpoint
- expose `fetchLastImport` in api client
- show last import date in `ImportZone`
- fetch last import dates in processing page

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e8cf5ac5c83278649ccabef9adab5