### PR TITLE
Add admin menu and tweak margins

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo } from 'react';
-import { Calculator, Palette } from 'lucide-react';
+import { Calculator, Palette, Settings } from 'lucide-react';
 import { fetchProducts, refreshProduction, refreshProductionByWeek } from './api';
 import ProcessingPage from './components/ProcessingPage';
 import FormattingPage from './components/FormattingPage';
+import AdminPage from './components/AdminPage';
 
 function App() {
-  const [currentPage, setCurrentPage] = useState<'processing' | 'formatting'>('processing');
+  const [currentPage, setCurrentPage] = useState<'processing' | 'formatting' | 'admin'>('processing');
   const [apiTestMessage, setApiTestMessage] = useState<string | null>(null);
   const [refreshMessage, setRefreshMessage] = useState<string | null>(null);
   const [selectedWeekStart, setSelectedWeekStart] = useState<Date | null>(null);
@@ -74,41 +75,55 @@ function App() {
     <div className="min-h-screen bg-black text-white flex flex-col">
       {/* Navigation Header */}
       <div className="bg-black border-b border-[#B8860B]/20">
-        <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-center space-x-4">
+        <div className="max-w-7xl mx-auto py-4 px-2 sm:px-4 lg:px-6">
+          <div className="flex items-center justify-between">
             <button
-              onClick={() => setCurrentPage('processing')}
-              className={`flex items-center space-x-2 px-6 py-3 rounded-lg font-semibold transition-all duration-200
-                ${currentPage === 'processing'
-                  ? 'bg-[#B8860B] text-black'
-                  : 'bg-zinc-800 text-white hover:bg-zinc-700'
-                }`}
+              onClick={() => setCurrentPage('admin')}
+              className="flex items-center space-x-2 px-4 py-2 rounded-lg font-semibold bg-zinc-800 text-white hover:bg-zinc-700 transition-all"
             >
-              <Calculator className="w-5 h-5" />
-              <span>Étape 1 - Calculs et Traitement</span>
+              <Settings className="w-5 h-5" />
+              <span>Admin</span>
             </button>
-            <button
-              onClick={() => setCurrentPage('formatting')}
-              className={`flex items-center space-x-2 px-6 py-3 rounded-lg font-semibold transition-all duration-200
-                ${currentPage === 'formatting'
-                  ? 'bg-[#B8860B] text-black'
-                  : 'bg-zinc-800 text-white hover:bg-zinc-700'
-                }`}
-            >
-              <Palette className="w-5 h-5" />
-              <span>Étape 2 - Mise en Forme</span>
-            </button>
+            <div className="flex flex-wrap justify-center gap-2 sm:gap-4">
+              <button
+                onClick={() => setCurrentPage('processing')}
+                className={`flex items-center space-x-2 px-6 py-3 rounded-lg font-semibold transition-all duration-200
+                  ${currentPage === 'processing'
+                    ? 'bg-[#B8860B] text-black'
+                    : 'bg-zinc-800 text-white hover:bg-zinc-700'
+                  }`}
+              >
+                <Calculator className="w-5 h-5" />
+                <span>Étape 1 - Calculs et Traitement</span>
+              </button>
+              <button
+                onClick={() => setCurrentPage('formatting')}
+                className={`flex items-center space-x-2 px-6 py-3 rounded-lg font-semibold transition-all duration-200
+                  ${currentPage === 'formatting'
+                    ? 'bg-[#B8860B] text-black'
+                    : 'bg-zinc-800 text-white hover:bg-zinc-700'
+                  }`}
+              >
+                <Palette className="w-5 h-5" />
+                <span>Étape 2 - Mise en Forme</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
 
       {/* Page Content */}
-      {currentPage === 'processing' ? (
+      {currentPage === 'processing' && (
         <ProcessingPage onNext={() => setCurrentPage('formatting')} />
-      ) : (
+      )}
+      {currentPage === 'formatting' && (
         <FormattingPage onBack={() => setCurrentPage('processing')} />
       )}
-      <div className="text-center mt-12 mb-8">
+      {currentPage === 'admin' && (
+        <AdminPage onBack={() => setCurrentPage('processing')} />
+      )}
+      {currentPage !== 'admin' && (
+      <div className="text-center mt-8 mb-6">
         <button
           onClick={handleApiTest}
           className="px-4 py-2 bg-[#B8860B] text-black rounded-lg hover:bg-[#B8860B]/90 font-semibold"
@@ -150,6 +165,7 @@ function App() {
           )}
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import HotwavAdmin from './HotwavAdmin';
+import AccessoriesAdmin from './AccessoriesAdmin';
+
+interface AdminPageProps {
+  onBack: () => void;
+}
+
+function AdminPage({ onBack }: AdminPageProps) {
+  const [showHotwav, setShowHotwav] = useState(false);
+  const [showAccessories, setShowAccessories] = useState(false);
+
+  return (
+    <div className="max-w-5xl mx-auto px-2 sm:px-4 py-6 sm:py-8">
+      <button
+        onClick={onBack}
+        className="flex items-center space-x-2 px-4 py-2 bg-zinc-800 text-white rounded-lg hover:bg-zinc-700 transition-colors mb-6"
+      >
+        <ArrowLeft className="w-5 h-5" />
+        <span>Retour</span>
+      </button>
+      <h1 className="text-4xl font-bold text-center mb-6">Administration</h1>
+      <div className="flex justify-center space-x-4">
+        <button
+          onClick={() => setShowHotwav(true)}
+          className="px-6 py-3 bg-[#B8860B] text-black rounded-lg font-semibold hover:bg-[#B8860B]/90"
+        >
+          Produits Hotwav
+        </button>
+        <button
+          onClick={() => setShowAccessories(true)}
+          className="px-6 py-3 bg-[#B8860B] text-black rounded-lg font-semibold hover:bg-[#B8860B]/90"
+        >
+          Accessoires
+        </button>
+      </div>
+      <HotwavAdmin
+        isVisible={showHotwav}
+        onClose={() => setShowHotwav(false)}
+        onSave={() => {}}
+        initialProducts={[]}
+      />
+      <AccessoriesAdmin
+        isVisible={showAccessories}
+        onClose={() => setShowAccessories(false)}
+        onSave={() => {}}
+        initialAccessories={[]}
+      />
+    </div>
+  );
+}
+
+export default AdminPage;

--- a/src/components/FormattingPage.tsx
+++ b/src/components/FormattingPage.tsx
@@ -353,7 +353,7 @@ function FormattingPage({ onBack }: FormattingPageProps) {
   const uniqueBrands = Array.from(new Set(previewData.map(p => p.brand))).sort();
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-12">
+    <div className="max-w-6xl mx-auto px-2 sm:px-4 py-6 sm:py-8">
       <div className="flex items-center justify-between mb-8">
         <button
           onClick={onBack}

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -204,7 +204,7 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
   }, [suppliers, refreshLastImports]);
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-12">
+    <div className="max-w-4xl mx-auto px-2 sm:px-4 py-6 sm:py-8">
       <h1 className="text-4xl font-bold text-center mb-2">Étape 1 - Calculs et Traitement</h1>
       <p className="text-center text-[#B8860B] mb-4">Traitez vos fichiers Excel avec calculs TCP et marges</p>
       <p className="text-center text-zinc-400 mb-4">Semaine en cours : {getCurrentWeekYear()}</p>


### PR DESCRIPTION
## Summary
- introduce an `AdminPage` component with modal access to Hotwav/Accessories admin
- reduce padding on main pages for tighter margins
- add responsive navigation header with a new Admin button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686fc9a66b50832781319466a28d7c8d