### PR TITLE
Enhance product page filters

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -457,6 +457,30 @@ def create_app():
             }
         )
 
+    @app.route("/brands", methods=["GET"])
+    def list_brands():
+        brands = Brand.query.all()
+        result = [{"id": b.id, "brand": b.brand} for b in brands]
+        return jsonify(result)
+
+    @app.route("/colors", methods=["GET"])
+    def list_colors():
+        colors = Color.query.all()
+        result = [{"id": c.id, "color": c.color} for c in colors]
+        return jsonify(result)
+
+    @app.route("/memory_options", methods=["GET"])
+    def list_memory_options():
+        memories = MemoryOption.query.all()
+        result = [{"id": m.id, "memory": m.memory} for m in memories]
+        return jsonify(result)
+
+    @app.route("/device_types", methods=["GET"])
+    def list_device_types():
+        types = DeviceType.query.all()
+        result = [{"id": t.id, "type": t.type} for t in types]
+        return jsonify(result)
+
     @app.route("/exclusions", methods=["GET"])
     def list_exclusions():
         exclusions = Exclusion.query.all()

--- a/src/api.ts
+++ b/src/api.ts
@@ -125,3 +125,35 @@ export async function fetchProductCalculations() {
   }
   return res.json();
 }
+
+export async function fetchBrands() {
+  const res = await fetch(`${API_BASE}/brands`);
+  if (!res.ok) {
+    throw new Error('Erreur lors du chargement des marques');
+  }
+  return res.json();
+}
+
+export async function fetchColors() {
+  const res = await fetch(`${API_BASE}/colors`);
+  if (!res.ok) {
+    throw new Error('Erreur lors du chargement des couleurs');
+  }
+  return res.json();
+}
+
+export async function fetchMemoryOptions() {
+  const res = await fetch(`${API_BASE}/memory_options`);
+  if (!res.ok) {
+    throw new Error('Erreur lors du chargement des mémoires');
+  }
+  return res.json();
+}
+
+export async function fetchDeviceTypes() {
+  const res = await fetch(`${API_BASE}/device_types`);
+  if (!res.ok) {
+    throw new Error('Erreur lors du chargement des types');
+  }
+  return res.json();
+}

--- a/src/components/ProductsPage.tsx
+++ b/src/components/ProductsPage.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
-import { fetchProductCalculations } from '../api';
+import {
+  fetchProductCalculations,
+  fetchBrands,
+  fetchColors,
+  fetchMemoryOptions,
+  fetchDeviceTypes,
+} from '../api';
 
 interface ProductCalculation {
   [key: string]: string | number | null;
@@ -17,6 +23,10 @@ function ProductsPage({ onBack }: ProductsPageProps) {
   const [showColumnMenu, setShowColumnMenu] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(20);
+  const [brandOptions, setBrandOptions] = useState<string[]>([]);
+  const [colorOptions, setColorOptions] = useState<string[]>([]);
+  const [memoryOptions, setMemoryOptions] = useState<string[]>([]);
+  const [typeOptions, setTypeOptions] = useState<string[]>([]);
 
   const columns: { key: string; label: string }[] = [
     { key: 'id', label: 'ID' },
@@ -43,7 +53,56 @@ function ProductsPage({ onBack }: ProductsPageProps) {
         setVisibleColumns(columns.map((c) => c.key));
       })
       .catch(() => setData([]));
+
+    Promise.all([
+      fetchBrands(),
+      fetchColors(),
+      fetchMemoryOptions(),
+      fetchDeviceTypes(),
+    ])
+      .then(([brands, colors, memories, types]) => {
+        setBrandOptions(brands.map((b: any) => b.brand));
+        setColorOptions(colors.map((c: any) => c.color));
+        setMemoryOptions(memories.map((m: any) => m.memory));
+        setTypeOptions(types.map((t: any) => t.type));
+      })
+      .catch(() => {
+        setBrandOptions([]);
+        setColorOptions([]);
+        setMemoryOptions([]);
+        setTypeOptions([]);
+      });
   }, []);
+
+  useEffect(() => {
+    const usedBrands = Array.from(
+      new Set(data.map((d) => d.brand).filter(Boolean))
+    );
+    if (usedBrands.length) {
+      setBrandOptions((prev) => Array.from(new Set([...prev, ...usedBrands])));
+    }
+
+    const usedColors = Array.from(
+      new Set(data.map((d) => d.color).filter(Boolean))
+    );
+    if (usedColors.length) {
+      setColorOptions((prev) => Array.from(new Set([...prev, ...usedColors])));
+    }
+
+    const usedMemories = Array.from(
+      new Set(data.map((d) => d.memory).filter(Boolean))
+    );
+    if (usedMemories.length) {
+      setMemoryOptions((prev) => Array.from(new Set([...prev, ...usedMemories])));
+    }
+
+    const usedTypes = Array.from(
+      new Set(data.map((d) => d.type).filter(Boolean))
+    );
+    if (usedTypes.length) {
+      setTypeOptions((prev) => Array.from(new Set([...prev, ...usedTypes])));
+    }
+  }, [data]);
 
   useEffect(() => {
     setCurrentPage(1);
@@ -53,6 +112,12 @@ function ProductsPage({ onBack }: ProductsPageProps) {
     columns.every((col) => {
       if (!filters[col.key]) return true;
       const value = row[col.key];
+      if (['brand', 'memory', 'color', 'type'].includes(col.key)) {
+        return (
+          String(value ?? '').toLowerCase() ===
+          filters[col.key].toLowerCase()
+        );
+      }
       return String(value ?? '')
         .toLowerCase()
         .includes(filters[col.key].toLowerCase());
@@ -171,14 +236,38 @@ function ProductsPage({ onBack }: ProductsPageProps) {
                 (col) =>
                   visibleColumns.includes(col.key) && (
                     <th key={col.key} className="px-3 py-1 border-b border-zinc-700">
-                      <input
-                        type="text"
-                        value={filters[col.key] || ''}
-                        onChange={(e) =>
-                          setFilters({ ...filters, [col.key]: e.target.value })
-                        }
-                        className="w-full px-2 py-1 bg-zinc-900 border border-zinc-600 rounded"
-                      />
+                      {['brand', 'memory', 'color', 'type'].includes(col.key) ? (
+                        <select
+                          value={filters[col.key] || ''}
+                          onChange={(e) =>
+                            setFilters({ ...filters, [col.key]: e.target.value })
+                          }
+                          className="w-full px-2 py-1 bg-zinc-900 border border-zinc-600 rounded"
+                        >
+                          <option value="">Tous</option>
+                          {(col.key === 'brand'
+                            ? brandOptions
+                            : col.key === 'memory'
+                            ? memoryOptions
+                            : col.key === 'color'
+                            ? colorOptions
+                            : typeOptions
+                          ).map((opt) => (
+                            <option key={opt} value={opt}>
+                              {opt}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <input
+                          type="text"
+                          value={filters[col.key] || ''}
+                          onChange={(e) =>
+                            setFilters({ ...filters, [col.key]: e.target.value })
+                          }
+                          className="w-full px-2 py-1 bg-zinc-900 border border-zinc-600 rounded"
+                        />
+                      )}
                     </th>
                   )
               )}


### PR DESCRIPTION
## Summary
- add API endpoints to list brands, colors, memory options and device types
- expose new fetching helpers in the front-end
- use dropdown filters for reference columns on the products page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `make test` *(fails: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_686fdf6308a48327b45c0b7cf5b0cb5c