### PR TITLE
Refactor WeekToolbar layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ function App() {
     <div className="min-h-screen bg-black text-white flex flex-col">
       {/* Navigation Header */}
       <div className="bg-black border-b border-[#B8860B]/20">
-        <div className="max-w-7xl mx-auto py-4 px-2 sm:px-4 lg:px-6">
+        <div className="max-w-7xl mx-auto py-4 px-1 sm:px-2 lg:px-4">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="flex flex-wrap justify-center gap-2 sm:gap-4">
               <button

--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -12,7 +12,7 @@ function AdminPage({ onBack }: AdminPageProps) {
   const [showTranslations, setShowTranslations] = useState(false);
 
   return (
-    <div className="max-w-6xl mx-auto px-2 sm:px-4 py-6 sm:py-8">
+    <div className="max-w-6xl mx-auto px-1 sm:px-2 py-6 sm:py-8">
       <button
         onClick={onBack}
         className="flex items-center space-x-2 px-4 py-2 bg-zinc-800 text-white rounded-lg hover:bg-zinc-700 transition-colors mb-6"

--- a/src/components/FormattingPage.tsx
+++ b/src/components/FormattingPage.tsx
@@ -354,7 +354,7 @@ function FormattingPage({ onBack }: FormattingPageProps) {
   const uniqueBrands = Array.from(new Set(previewData.map(p => p.brand))).sort();
 
   return (
-    <div className="max-w-7xl mx-auto px-2 sm:px-4 py-6 sm:py-8">
+    <div className="max-w-7xl mx-auto px-1 sm:px-2 py-6 sm:py-8">
       <WeekToolbar />
       <div className="flex items-center justify-between mb-8">
         <button

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -205,7 +205,7 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
   }, [suppliers, refreshLastImports]);
 
   return (
-    <div className="max-w-6xl mx-auto px-2 sm:px-4 py-6 sm:py-8">
+    <div className="max-w-6xl mx-auto px-1 sm:px-2 py-6 sm:py-8">
       <WeekToolbar />
       <h1 className="text-4xl font-bold text-center mb-2">Étape 1 - Calculs et Traitement</h1>
       <p className="text-center text-[#B8860B] mb-4">Traitez vos fichiers Excel avec calculs TCP et marges</p>

--- a/src/components/ProductsPage.tsx
+++ b/src/components/ProductsPage.tsx
@@ -185,7 +185,7 @@ function ProductsPage({ onBack }: ProductsPageProps) {
   );
 
   return (
-    <div className="max-w-6xl mx-auto px-2 sm:px-4 py-6 sm:py-8">
+    <div className="max-w-6xl mx-auto px-1 sm:px-2 py-6 sm:py-8">
       <WeekToolbar />
       <button
         onClick={onBack}

--- a/src/components/WeekToolbar.tsx
+++ b/src/components/WeekToolbar.tsx
@@ -4,7 +4,6 @@ import { exportCalculations, refreshProduction, refreshProductionByWeek } from '
 import { getCurrentTimestamp, getCurrentWeekYear } from '../utils/date';
 
 function WeekToolbar() {
-  const [selectedWeekStart, setSelectedWeekStart] = useState<Date | null>(null);
   const [message, setMessage] = useState<string | null>(null);
 
   const getStartOfWeek = (date: Date) => {
@@ -59,55 +58,53 @@ function WeekToolbar() {
     }
   }, []);
 
-  const handleRefreshWeek = useCallback(async () => {
+  const handleRefreshWeek = useCallback(async (weekStart: Date) => {
     setMessage(null);
-    if (!selectedWeekStart) return;
     try {
-      await refreshProductionByWeek([selectedWeekStart]);
+      await refreshProductionByWeek([weekStart]);
       setMessage('Semaine mise à jour');
     } catch {
       setMessage("Erreur lors du rafraîchissement des données de la semaine");
     }
-  }, [selectedWeekStart]);
+  }, []);
 
   return (
     <div className="mb-4">
-      <div className="flex flex-wrap justify-center items-center gap-4">
-        <span className="text-zinc-400">Semaine en cours : {getCurrentWeekYear()}</span>
-        <button
-          onClick={handleDownload}
-          className="px-4 py-2 bg-[#B8860B] text-black rounded-lg flex items-center space-x-2 hover:bg-[#B8860B]/90 font-semibold"
-        >
-          <Download className="w-5 h-5" />
-          <span>Télécharger</span>
-        </button>
-        <button
-          onClick={handleRefresh}
-          className="px-4 py-2 bg-[#B8860B] text-black rounded-lg hover:bg-[#B8860B]/90 font-semibold"
-        >
-          Tout rafraîchir
-        </button>
-        <div className="flex items-center space-x-2">
-          <select
-            value={selectedWeekStart ? selectedWeekStart.toISOString() : ''}
-            onChange={(e) =>
-              setSelectedWeekStart(e.target.value ? new Date(e.target.value) : null)
-            }
-            className="bg-zinc-800 border border-zinc-700 rounded-lg px-2 py-1 text-white"
+      <div className="flex flex-col sm:flex-row sm:justify-between items-center gap-4">
+        <div className="flex items-center gap-4">
+          <span className="text-zinc-400">Semaine en cours : {getCurrentWeekYear()}</span>
+          <button
+            onClick={handleDownload}
+            className="px-4 py-2 bg-[#B8860B] text-black rounded-lg flex items-center space-x-2 hover:bg-[#B8860B]/90 font-semibold"
           >
-            <option value="">Choisir la semaine</option>
+            <Download className="w-5 h-5" />
+            <span>Télécharger</span>
+          </button>
+        </div>
+        <div className="flex flex-col items-start gap-2">
+          <button
+            onClick={handleRefresh}
+            className="px-4 py-2 bg-[#B8860B] text-black rounded-lg hover:bg-[#B8860B]/90 font-semibold"
+          >
+            Tout rafraîchir
+          </button>
+          <select
+            defaultValue=""
+            onChange={async (e) => {
+              if (e.target.value) {
+                await handleRefreshWeek(new Date(e.target.value));
+                e.target.value = '';
+              }
+            }}
+            className="px-4 py-2 bg-[#B8860B] text-black rounded-lg hover:bg-[#B8860B]/90 font-semibold cursor-pointer"
+          >
+            <option value="">Rafraîchir une semaine</option>
             {weekOptions.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>
             ))}
           </select>
-          <button
-            onClick={handleRefreshWeek}
-            className="px-4 py-2 bg-[#B8860B] text-black rounded-lg hover:bg-[#B8860B]/90 font-semibold"
-          >
-            Rafraîchir
-          </button>
         </div>
       </div>
       {message && (

--- a/src/components/WeekToolbar.tsx
+++ b/src/components/WeekToolbar.tsx
@@ -81,7 +81,7 @@ function WeekToolbar() {
             <span>Télécharger</span>
           </button>
         </div>
-        <div className="flex flex-col items-start gap-2">
+        <div className="flex flex-col items-end gap-2">
           <button
             onClick={handleRefresh}
             className="px-4 py-2 bg-[#B8860B] text-black rounded-lg hover:bg-[#B8860B]/90 font-semibold"


### PR DESCRIPTION
## Summary
- adjust WeekToolbar UI
  - arrange week display and download button on the same line
  - stack refresh controls vertically and merge the week selector with refresh action

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6870b2ff6bd48327a5a7a73bc21b9c59