### PR TITLE
Fix dropdown defaults in product admin

### DIFF
--- a/src/components/ProductAdmin.tsx
+++ b/src/components/ProductAdmin.tsx
@@ -126,10 +126,10 @@ function ProductAdmin() {
         ean: '',
         model: '',
         description: '',
-        brand_id: brands[0]?.id ?? null,
-        memory_id: memories[0]?.id ?? null,
-        color_id: colors[0]?.id ?? null,
-        type_id: types[0]?.id ?? null,
+        brand_id: null,
+        memory_id: null,
+        color_id: null,
+        type_id: null,
       },
     ]);
   };
@@ -169,36 +169,64 @@ function ProductAdmin() {
             />
             <select
               value={p.brand_id ?? ''}
-              onChange={(e) => handleChange(p.id, 'brand_id', Number(e.target.value))}
+              onChange={(e) =>
+                handleChange(
+                  p.id,
+                  'brand_id',
+                  e.target.value === '' ? null : Number(e.target.value)
+                )
+              }
               className="px-2 py-1 bg-zinc-700 rounded"
             >
+              <option value="">null</option>
               {brands.map((b) => (
                 <option key={b.id} value={b.id}>{b.brand}</option>
               ))}
             </select>
             <select
               value={p.memory_id ?? ''}
-              onChange={(e) => handleChange(p.id, 'memory_id', Number(e.target.value))}
+              onChange={(e) =>
+                handleChange(
+                  p.id,
+                  'memory_id',
+                  e.target.value === '' ? null : Number(e.target.value)
+                )
+              }
               className="px-2 py-1 bg-zinc-700 rounded"
             >
+              <option value="">null</option>
               {memories.map((m) => (
                 <option key={m.id} value={m.id}>{m.memory}</option>
               ))}
             </select>
             <select
               value={p.color_id ?? ''}
-              onChange={(e) => handleChange(p.id, 'color_id', Number(e.target.value))}
+              onChange={(e) =>
+                handleChange(
+                  p.id,
+                  'color_id',
+                  e.target.value === '' ? null : Number(e.target.value)
+                )
+              }
               className="px-2 py-1 bg-zinc-700 rounded"
             >
+              <option value="">null</option>
               {colors.map((c) => (
                 <option key={c.id} value={c.id}>{c.color}</option>
               ))}
             </select>
             <select
               value={p.type_id ?? ''}
-              onChange={(e) => handleChange(p.id, 'type_id', Number(e.target.value))}
+              onChange={(e) =>
+                handleChange(
+                  p.id,
+                  'type_id',
+                  e.target.value === '' ? null : Number(e.target.value)
+                )
+              }
               className="px-2 py-1 bg-zinc-700 rounded"
             >
+              <option value="">null</option>
               {types.map((t) => (
                 <option key={t.id} value={t.id}>{t.type}</option>
               ))}


### PR DESCRIPTION
## Summary
- update ProductAdmin form to treat missing dropdown values as null
- add explicit `null` option to dropdowns so blank data isn't shown with a table value

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68712ef90a908327ac147611875201be