### PR TITLE
Update Makefile and dropdown default behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,15 +24,11 @@ dist-ssr
 *.sw?
 .venv
 .env
+.flake8
 
-backend/__pycache__/
-backend/__pycache__/*
 backend/instance/
 backend/instance/*
-backend/alembic/__pycache__/
-backend/alembic/__pycache__/*
-backend/alembic/versions/*
-backend/routes/__pycache__/
-backend/routes/__pycache__/*
-backend/utils/__pycache__/
-backend/utils/__pycache__/*
+backend/alembic/*
+
+**/__pycache__
+**/*.pyc

--- a/src/components/ProductAdmin.tsx
+++ b/src/components/ProductAdmin.tsx
@@ -60,10 +60,10 @@ function ProductAdmin() {
           ean: p.ean ?? '',
           model: p.name ?? '',
           description: p.description ?? '',
-          brand_id: null,
-          memory_id: null,
-          color_id: null,
-          type_id: null,
+          brand_id: p.brand_id ?? null,
+          memory_id: p.memory_id ?? null,
+          color_id: p.color_id ?? null,
+          type_id: p.type_id ?? null,
         }))
       );
     } catch {
@@ -169,8 +169,13 @@ function ProductAdmin() {
             />
             <select
               value={p.brand_id ?? ''}
-              onChange={(e) => handleChange(p.id, 'brand_id', Number(e.target.value === '' ? null : Number(e.target.value)
-              ))}
+              onChange={(e) =>
+                handleChange(
+                  p.id,
+                  'brand_id',
+                  e.target.value === '' ? null : Number(e.target.value)
+                )
+              }
               className="px-2 py-1 bg-zinc-700 rounded"
             >
               <option value="">null</option>
@@ -180,8 +185,13 @@ function ProductAdmin() {
             </select>
             <select
               value={p.memory_id ?? ''}
-              onChange={(e) => handleChange(p.id, 'memory_id', Number(e.target.value === '' ? null : Number(e.target.value)
-              ))}
+              onChange={(e) =>
+                handleChange(
+                  p.id,
+                  'memory_id',
+                  e.target.value === '' ? null : Number(e.target.value)
+                )
+              }
               className="px-2 py-1 bg-zinc-700 rounded"
             >
               <option value="">null</option>
@@ -191,8 +201,13 @@ function ProductAdmin() {
             </select>
             <select
               value={p.color_id ?? ''}
-              onChange={(e) => handleChange(p.id, 'color_id', Number(e.target.value === '' ? null : Number(e.target.value)
-              ))}
+              onChange={(e) =>
+                handleChange(
+                  p.id,
+                  'color_id',
+                  e.target.value === '' ? null : Number(e.target.value)
+                )
+              }
               className="px-2 py-1 bg-zinc-700 rounded"
             >
               <option value="">null</option>
@@ -202,8 +217,13 @@ function ProductAdmin() {
             </select>
             <select
               value={p.type_id ?? ''}
-              onChange={(e) => handleChange(p.id, 'type_id', Number(e.target.value === '' ? null : Number(e.target.value)
-              ))}
+              onChange={(e) =>
+                handleChange(
+                  p.id,
+                  'type_id',
+                  e.target.value === '' ? null : Number(e.target.value)
+                )
+              }
               className="px-2 py-1 bg-zinc-700 rounded"
             >
               <option value="">null</option>


### PR DESCRIPTION
## Summary
- detect container execution in backend Makefile
- run Alembic and other commands directly when inside Docker
- load product dropdown values from API
- fix dropdown change handlers to keep empty option when value is null

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `make -C backend test` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_687131f2630c83279d710c9c293cef8f