### PR TITLE
Add filtered reference view

### DIFF
--- a/backend/routes/products.py
+++ b/backend/routes/products.py
@@ -283,6 +283,40 @@ def update_product(product_id):
     return jsonify({"status": "updated"})
 
 
+@bp.route("/products/bulk_update", methods=["PUT"])
+def bulk_update_products():
+    """Update multiple products in a single request."""
+    items = request.get_json(silent=True) or []
+    if not isinstance(items, list):
+        return jsonify({"error": "Invalid payload"}), 400
+
+    fields = [
+        "ean",
+        "model",
+        "description",
+        "brand_id",
+        "memory_id",
+        "color_id",
+        "type_id",
+    ]
+    updated_ids = []
+    for item in items:
+        pid = item.get("id")
+        if not pid:
+            continue
+        product = Product.query.get(pid)
+        if not product:
+            continue
+        for field in fields:
+            if field in item:
+                setattr(product, field, item[field])
+        updated_ids.append(pid)
+
+    if updated_ids:
+        db.session.commit()
+    return jsonify({"status": "success", "updated": updated_ids})
+
+
 @bp.route("/products/<int:product_id>", methods=["DELETE"])
 def delete_product(product_id):
     """Delete a product."""

--- a/src/api.ts
+++ b/src/api.ts
@@ -52,6 +52,18 @@ export async function updateProduct(id: number, data: any) {
   return res.json();
 }
 
+export async function bulkUpdateProducts(data: any[]) {
+  const res = await fetch(`${API_BASE}/products/bulk_update`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) {
+    throw new Error("Erreur lors de la mise à jour des produits");
+  }
+  return res.json();
+}
+
 export async function deleteProduct(id: number) {
   const res = await fetch(`${API_BASE}/products/${id}`, {
     method: 'DELETE'

--- a/src/components/MultiSelectFilter.tsx
+++ b/src/components/MultiSelectFilter.tsx
@@ -1,0 +1,59 @@
+import { useState, useRef, useEffect } from 'react';
+
+interface MultiSelectFilterProps {
+  options: string[];
+  selected: string[];
+  onChange: (values: string[]) => void;
+}
+
+function MultiSelectFilter({ options, selected, onChange }: MultiSelectFilterProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const toggleOption = (opt: string, checked: boolean) => {
+    if (checked) {
+      onChange([...selected, opt]);
+    } else {
+      onChange(selected.filter((v) => v !== opt));
+    }
+  };
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full px-2 py-1 bg-zinc-900 border border-zinc-600 rounded text-left overflow-hidden whitespace-nowrap text-ellipsis"
+      >
+        {selected.length ? selected.join(', ') : 'Tous'}
+      </button>
+      {open && (
+        <div className="absolute z-10 mt-1 max-h-60 overflow-auto bg-zinc-900 border border-zinc-600 rounded shadow-lg">
+          {options.map((opt) => (
+            <label key={opt} className="flex items-center space-x-2 px-2 py-1 hover:bg-zinc-800">
+              <input
+                type="checkbox"
+                checked={selected.includes(opt)}
+                onChange={(e) => toggleOption(opt, e.target.checked)}
+                className="rounded"
+              />
+              <span>{opt}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MultiSelectFilter;

--- a/src/components/ProductReference.tsx
+++ b/src/components/ProductReference.tsx
@@ -6,6 +6,7 @@ import {
   fetchMemoryOptions,
   fetchDeviceTypes,
 } from '../api';
+import MultiSelectFilter from './MultiSelectFilter';
 
 interface ProductItem {
   [key: string]: string | number | null;
@@ -187,31 +188,21 @@ function ProductReference() {
                   visibleColumns.includes(col.key) && (
                     <th key={col.key} className="px-3 py-1 border-b border-zinc-700">
                       {['brand', 'memory', 'color', 'type'].includes(col.key) ? (
-                        <select
-                          multiple
-                          size={3}
-                          value={(filters[col.key] as string[]) || []}
-                          onChange={(e) => {
-                            const selected = Array.from(e.target.selectedOptions).map(
-                              (o) => o.value
-                            );
-                            setFilters({ ...filters, [col.key]: selected });
-                          }}
-                          className="w-full px-2 py-1 bg-zinc-900 border border-zinc-600 rounded"
-                        >
-                          {(col.key === 'brand'
-                            ? brandOptions
-                            : col.key === 'memory'
-                            ? memoryOptions
-                            : col.key === 'color'
-                            ? colorOptions
-                            : typeOptions
-                          ).map((opt) => (
-                            <option key={opt} value={opt}>
-                              {opt}
-                            </option>
-                          ))}
-                        </select>
+                        <MultiSelectFilter
+                          options={
+                            col.key === 'brand'
+                              ? brandOptions
+                              : col.key === 'memory'
+                              ? memoryOptions
+                              : col.key === 'color'
+                              ? colorOptions
+                              : typeOptions
+                          }
+                          selected={(filters[col.key] as string[]) || []}
+                          onChange={(selected) =>
+                            setFilters({ ...filters, [col.key]: selected })
+                          }
+                        />
                       ) : (
                         <input
                           type="text"

--- a/src/components/ProductReference.tsx
+++ b/src/components/ProductReference.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useState } from 'react';
+import {
+  fetchProducts,
+  fetchBrands,
+  fetchColors,
+  fetchMemoryOptions,
+  fetchDeviceTypes,
+} from '../api';
+
+interface ProductItem {
+  [key: string]: string | number | null;
+}
+
+function ProductReference() {
+  const [data, setData] = useState<ProductItem[]>([]);
+  const [filters, setFilters] = useState<Record<string, string | string[]>>({});
+  const [visibleColumns, setVisibleColumns] = useState<string[]>([]);
+  const [showColumnMenu, setShowColumnMenu] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [rowsPerPage, setRowsPerPage] = useState(20);
+  const [brandOptions, setBrandOptions] = useState<string[]>([]);
+  const [colorOptions, setColorOptions] = useState<string[]>([]);
+  const [memoryOptions, setMemoryOptions] = useState<string[]>([]);
+  const [typeOptions, setTypeOptions] = useState<string[]>([]);
+
+  const columns: { key: string; label: string }[] = [
+    { key: 'id', label: 'ID' },
+    { key: 'model', label: 'Mod\u00e8le' },
+    { key: 'description', label: 'Description' },
+    { key: 'brand', label: 'Marque' },
+    { key: 'memory', label: 'M\u00e9moire' },
+    { key: 'color', label: 'Couleur' },
+    { key: 'type', label: 'Type' },
+    { key: 'ean', label: 'EAN' },
+  ];
+
+  useEffect(() => {
+    fetchProducts()
+      .then((res) => {
+        setData(res as ProductItem[]);
+        setVisibleColumns(columns.map((c) => c.key));
+      })
+      .catch(() => setData([]));
+
+    Promise.all([
+      fetchBrands(),
+      fetchColors(),
+      fetchMemoryOptions(),
+      fetchDeviceTypes(),
+    ])
+      .then(([brands, colors, memories, types]) => {
+        setBrandOptions((brands as any[]).map((b) => b.brand));
+        setColorOptions((colors as any[]).map((c) => c.color));
+        setMemoryOptions((memories as any[]).map((m) => m.memory));
+        setTypeOptions((types as any[]).map((t) => t.type));
+      })
+      .catch(() => {
+        setBrandOptions([]);
+        setColorOptions([]);
+        setMemoryOptions([]);
+        setTypeOptions([]);
+      });
+  }, []);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filters, rowsPerPage]);
+
+  const filteredData = data.filter((row) =>
+    columns.every((col) => {
+      const filterValue = filters[col.key];
+      if (
+        !filterValue ||
+        (Array.isArray(filterValue) && filterValue.length === 0)
+      )
+        return true;
+      const value = row[col.key];
+      if (['brand', 'memory', 'color', 'type'].includes(col.key)) {
+        return (filterValue as string[]).includes(String(value ?? ''));
+      }
+      return String(value ?? '')
+        .toLowerCase()
+        .includes((filterValue as string).toLowerCase());
+    })
+  );
+
+  const totalPages = Math.max(1, Math.ceil(filteredData.length / rowsPerPage));
+  const paginatedData = filteredData.slice(
+    (currentPage - 1) * rowsPerPage,
+    currentPage * rowsPerPage
+  );
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [totalPages, currentPage]);
+
+  const toggleColumn = (key: string) => {
+    setVisibleColumns((prev) =>
+      prev.includes(key) ? prev.filter((c) => c !== key) : [...prev, key]
+    );
+  };
+
+  const paginationControls = (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center space-x-2">
+        <button
+          onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+          disabled={currentPage === 1}
+          className="px-3 py-1 bg-zinc-800 rounded disabled:opacity-50"
+        >
+          Pr\u00e9c\u00e9dent
+        </button>
+        <span>
+          Page {currentPage} / {totalPages}
+        </span>
+        <button
+          onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+          disabled={currentPage === totalPages}
+          className="px-3 py-1 bg-zinc-800 rounded disabled:opacity-50"
+        >
+          Suivant
+        </button>
+      </div>
+      <div className="flex items-center space-x-2">
+        <label htmlFor="rowsPerPage" className="text-sm">
+          Lignes par page:
+        </label>
+        <select
+          id="rowsPerPage"
+          value={rowsPerPage}
+          onChange={(e) => setRowsPerPage(Number(e.target.value))}
+          className="bg-zinc-900 border border-zinc-600 rounded px-2 py-1"
+        >
+          <option value={10}>10</option>
+          <option value={20}>20</option>
+          <option value={50}>50</option>
+          <option value={100}>100</option>
+        </select>
+      </div>
+    </div>
+  );
+
+  return (
+    <div>
+      <div className="relative mb-4">
+        <button
+          onClick={() => setShowColumnMenu((s) => !s)}
+          className="px-4 py-2 bg-zinc-800 text-white rounded-lg hover:bg-zinc-700"
+        >
+          Colonnes
+        </button>
+        {showColumnMenu && (
+          <div className="absolute z-10 mt-2 p-4 bg-zinc-900 border border-zinc-700 rounded shadow-xl grid grid-cols-2 gap-2">
+            {columns.map((col) => (
+              <label key={col.key} className="flex items-center space-x-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={visibleColumns.includes(col.key)}
+                  onChange={() => toggleColumn(col.key)}
+                  className="rounded"
+                />
+                <span>{col.label}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+      {paginationControls}
+      <div className="overflow-auto mt-4">
+        <table className="min-w-full text-sm text-left border border-zinc-700">
+          <thead>
+            <tr className="bg-zinc-800">
+              {columns.map(
+                (col) =>
+                  visibleColumns.includes(col.key) && (
+                    <th key={col.key} className="px-3 py-2 border-b border-zinc-700">
+                      {col.label}
+                    </th>
+                  )
+              )}
+            </tr>
+            <tr>
+              {columns.map(
+                (col) =>
+                  visibleColumns.includes(col.key) && (
+                    <th key={col.key} className="px-3 py-1 border-b border-zinc-700">
+                      {['brand', 'memory', 'color', 'type'].includes(col.key) ? (
+                        <select
+                          multiple
+                          size={3}
+                          value={(filters[col.key] as string[]) || []}
+                          onChange={(e) => {
+                            const selected = Array.from(e.target.selectedOptions).map(
+                              (o) => o.value
+                            );
+                            setFilters({ ...filters, [col.key]: selected });
+                          }}
+                          className="w-full px-2 py-1 bg-zinc-900 border border-zinc-600 rounded"
+                        >
+                          {(col.key === 'brand'
+                            ? brandOptions
+                            : col.key === 'memory'
+                            ? memoryOptions
+                            : col.key === 'color'
+                            ? colorOptions
+                            : typeOptions
+                          ).map((opt) => (
+                            <option key={opt} value={opt}>
+                              {opt}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <input
+                          type="text"
+                          value={(filters[col.key] as string) || ''}
+                          onChange={(e) =>
+                            setFilters({ ...filters, [col.key]: e.target.value })
+                          }
+                          className="w-full px-2 py-1 bg-zinc-900 border border-zinc-600 rounded"
+                        />
+                      )}
+                    </th>
+                  )
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {paginatedData.map((row) => (
+              <tr key={String(row.id)} className="odd:bg-zinc-900 even:bg-zinc-800">
+                {columns.map(
+                  (col) =>
+                    visibleColumns.includes(col.key) && (
+                      <td key={col.key} className="px-3 py-1 border-b border-zinc-700">
+                        {String(row[col.key] ?? '')}
+                      </td>
+                    )
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-4">{paginationControls}</div>
+    </div>
+  );
+}
+
+export default ProductReference;

--- a/src/components/ProductsPage.tsx
+++ b/src/components/ProductsPage.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { fetchProductCalculations } from '../api';
-import ProductAdmin from './ProductAdmin';
+import ProductReference from './ProductReference';
 import WeekToolbar from './WeekToolbar';
 
 import {
@@ -314,7 +314,7 @@ function ProductsPage({ onBack }: ProductsPageProps) {
           <div className="mt-4">{paginationControls}</div>
         </>
       )}
-      {tab === 'reference' && <ProductAdmin />}
+      {tab === 'reference' && <ProductReference />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show product reference list using new `ProductReference` table component
- allow column filters with multi‑select options

## Testing
- `pytest`
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872748f816c832796de0c11cd1b97b2