### PR TITLE
Add import overwrite confirmation

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -91,6 +91,14 @@ export async function fetchLastImport(id: number): Promise<{ import_date: string
   return res.json();
 }
 
+export async function verifyImport(id: number) {
+  const res = await fetch(`${API_BASE}/verify_import/${id}`);
+  if (!res.ok) {
+    throw new Error("Erreur lors de la vérification de l'import");
+  }
+  return res.json();
+}
+
 
 export async function calculateProducts() {
   const res = await fetch(`${API_BASE}/calculate_products`, {

--- a/src/components/ProcessingPage.tsx
+++ b/src/components/ProcessingPage.tsx
@@ -11,7 +11,8 @@ import {
   calculateProducts,
   createImport,
   fetchLastImport,
-  fetchSuppliers
+  fetchSuppliers,
+  verifyImport
 } from '../api';
 import { getCurrentTimestamp, getCurrentWeekYear, getWeekYear } from '../utils/date';
 
@@ -158,6 +159,19 @@ function ProcessingPage({ onNext }: ProcessingPageProps) {
       for (const f of suppliers) {
         const file = files[f.id];
         if (file) {
+          try {
+            const check = await verifyImport(f.id);
+            if (check.status === 'error') {
+              const confirmOverride = window.confirm(
+                `Un import a déjà été réalisé cette semaine pour ${f.name}. Voulez-vous écraser les données ?`
+              );
+              if (!confirmOverride) {
+                continue;
+              }
+            }
+          } catch {
+            // ignore verification errors and proceed
+          }
           await createImport(file, f.id);
         }
       }


### PR DESCRIPTION
## Summary
- call new `verify_import` endpoint from ProcessingPage
- if an import already exists this week, ask for confirmation before overwriting
- expose `verifyImport` helper in api.ts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6873fb4769948327b00f437a323e7ebe