### PR TITLE
Add statistics page for price trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Application complète de gestion de tarifs avec système de panier et commande p
 - Vue filtrable et édition en masse du référentiel **(validée)**
 - Ajout/modification/suppression de produits **(validée)**
 
+### 📊 Statistiques
+- Graphiques dynamiques par semaine, fournisseur et marque **(nouveau)**
+
 ## Configuration EmailJS
 
 Pour activer l'envoi d'emails, configurez EmailJS :
@@ -105,6 +108,7 @@ src/
 │   ├── ReferenceAdmin.tsx     # Tables de référence
 │   ├── SearchControls.tsx     # Outils de recherche
 │   ├── TranslationAdmin.tsx   # Cohérence des couleurs
+│   ├── StatisticsPage.tsx     # Visualisation des statistiques
 │   └── WeekToolbar.tsx        # Outils hebdomadaires
 ├── utils/
 │   ├── date.ts                # Fonctions de date

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Application complète de gestion de tarifs avec système de panier et commande p
 - Ajout/modification/suppression de produits **(validée)**
 
 ### 📊 Statistiques
-- Graphiques dynamiques par semaine, fournisseur et marque **(nouveau)**
+- Graphiques dynamiques par semaine avec filtres fournisseur, produit et marque **(nouveau)**
 
 ## Configuration EmailJS
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Application complète de gestion de tarifs avec système de panier et commande p
 - Ajout/modification/suppression de produits **(validée)**
 
 ### 📊 Statistiques
-- Graphiques dynamiques par semaine avec filtres fournisseur, produit et marque **(nouveau)**
+- Graphiques dynamiques par semaine avec filtres fournisseur, marque et intervalle de semaines
+- Comparaison de l'évolution d'un produit selon les fournisseurs
 
 ## Configuration EmailJS
 

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,4 +1,4 @@
-from . import imports, products, references, main
+from . import imports, products, references, main, stats
 
 
 def register_routes(app):
@@ -6,3 +6,4 @@ def register_routes(app):
     app.register_blueprint(imports.bp)
     app.register_blueprint(products.bp)
     app.register_blueprint(references.bp)
+    app.register_blueprint(stats.bp)

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -5,20 +5,34 @@ from models import ProductCalculation, Product, Supplier, Brand
 bp = Blueprint("stats", __name__)
 
 
+def _parse_week(w):
+    if not w:
+        return None
+    w = w.strip()
+    if w.startswith("S"):
+        week_part, year_part = w[1:].split("-")
+    elif "-W" in w:
+        year_part, week_part = w.split("-W")
+    else:
+        year_part, week_part = w.split("-")
+    return int(year_part), int(week_part)
+
+
 @bp.route("/price_stats", methods=["GET"])
 def price_stats():
-    """Aggregate average price per week with optional filters."""
+    """Return average prices per week. If a product_id is supplied, results are
+    grouped by supplier, otherwise aggregated globally."""
 
     supplier_id = request.args.get("supplier_id", type=int)
     brand_id = request.args.get("brand_id", type=int)
     product_id = request.args.get("product_id", type=int)
+    start_week = request.args.get("start_week")
+    end_week = request.args.get("end_week")
 
     query = (
-        ProductCalculation.query.join(
-            Supplier, ProductCalculation.supplier_id == Supplier.id
-        )
-        .join(Product, ProductCalculation.product_id == Product.id)
-        .join(Brand, Product.brand_id == Brand.id)
+        ProductCalculation.query.join(Supplier)
+        .join(Product)
+        .join(Brand)
     )
 
     if supplier_id:
@@ -28,40 +42,51 @@ def price_stats():
     if product_id:
         query = query.filter(Product.id == product_id)
 
-    results = (
-        query.with_entities(
+    if start_week:
+        sy, sw = _parse_week(start_week)
+        query = query.filter(
+            extract("year", ProductCalculation.date) * 100
+            + extract("week", ProductCalculation.date)
+            >= sy * 100 + sw
+        )
+    if end_week:
+        ey, ew = _parse_week(end_week)
+        query = query.filter(
+            extract("year", ProductCalculation.date) * 100
+            + extract("week", ProductCalculation.date)
+            <= ey * 100 + ew
+        )
+
+    week_field = extract("week", ProductCalculation.date).label("week")
+    year_field = extract("year", ProductCalculation.date).label("year")
+
+    if product_id:
+        fields = [
             Supplier.name.label("supplier"),
-            Product.id.label("product_id"),
-            Product.model.label("product"),
-            Brand.brand.label("brand"),
-            extract("week", ProductCalculation.date).label("week"),
-            extract("year", ProductCalculation.date).label("year"),
+            week_field,
+            year_field,
             func.avg(ProductCalculation.price).label("avg_price"),
-        )
-        .group_by(
-            Supplier.name,
-            Product.id,
-            Product.model,
-            Brand.brand,
-            extract("year", ProductCalculation.date),
-            extract("week", ProductCalculation.date),
-        )
-        .order_by(
-            extract("year", ProductCalculation.date),
-            extract("week", ProductCalculation.date),
-        )
+        ]
+        group_by = [Supplier.name, week_field, year_field]
+    else:
+        fields = [week_field, year_field, func.avg(ProductCalculation.price).label("avg_price")]
+        group_by = [week_field, year_field]
+
+    results = (
+        query.with_entities(*fields)
+        .group_by(*group_by)
+        .order_by(year_field, week_field)
         .all()
     )
 
-    data = [
-        {
-            "supplier": r.supplier,
-            "product_id": r.product_id,
-            "product": r.product,
-            "brand": r.brand,
+    data = []
+    for r in results:
+        entry = {
             "week": f"S{int(r.week):02d}-{int(r.year)}",
             "avg_price": float(r.avg_price),
         }
-        for r in results
-    ]
+        if product_id:
+            entry["supplier"] = r.supplier
+        data.append(entry)
+
     return jsonify(data)

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -1,0 +1,46 @@
+from flask import Blueprint, jsonify
+from sqlalchemy import func, extract
+from models import ProductCalculation, Product, Supplier, Brand
+
+bp = Blueprint("stats", __name__)
+
+
+@bp.route("/price_stats", methods=["GET"])
+def price_stats():
+    """Aggregate average price per week, supplier and brand."""
+    results = (
+        ProductCalculation.query.join(
+            Supplier, ProductCalculation.supplier_id == Supplier.id
+        )
+        .join(Product, ProductCalculation.product_id == Product.id)
+        .join(Brand, Product.brand_id == Brand.id)
+        .with_entities(
+            Supplier.name.label("supplier"),
+            Brand.brand.label("brand"),
+            extract("week", ProductCalculation.date).label("week"),
+            extract("year", ProductCalculation.date).label("year"),
+            func.avg(ProductCalculation.price).label("avg_price"),
+        )
+        .group_by(
+            Supplier.name,
+            Brand.brand,
+            extract("year", ProductCalculation.date),
+            extract("week", ProductCalculation.date),
+        )
+        .order_by(
+            extract("year", ProductCalculation.date),
+            extract("week", ProductCalculation.date),
+        )
+        .all()
+    )
+
+    data = [
+        {
+            "supplier": r.supplier,
+            "brand": r.brand,
+            "week": f"S{int(r.week):02d}-{int(r.year)}",
+            "avg_price": float(r.avg_price),
+        }
+        for r in results
+    ]
+    return jsonify(data)

--- a/backend/routes/stats.py
+++ b/backend/routes/stats.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from sqlalchemy import func, extract
 from models import ProductCalculation, Product, Supplier, Brand
 
@@ -7,15 +7,32 @@ bp = Blueprint("stats", __name__)
 
 @bp.route("/price_stats", methods=["GET"])
 def price_stats():
-    """Aggregate average price per week, supplier and brand."""
-    results = (
+    """Aggregate average price per week with optional filters."""
+
+    supplier_id = request.args.get("supplier_id", type=int)
+    brand_id = request.args.get("brand_id", type=int)
+    product_id = request.args.get("product_id", type=int)
+
+    query = (
         ProductCalculation.query.join(
             Supplier, ProductCalculation.supplier_id == Supplier.id
         )
         .join(Product, ProductCalculation.product_id == Product.id)
         .join(Brand, Product.brand_id == Brand.id)
-        .with_entities(
+    )
+
+    if supplier_id:
+        query = query.filter(ProductCalculation.supplier_id == supplier_id)
+    if brand_id:
+        query = query.filter(Product.brand_id == brand_id)
+    if product_id:
+        query = query.filter(Product.id == product_id)
+
+    results = (
+        query.with_entities(
             Supplier.name.label("supplier"),
+            Product.id.label("product_id"),
+            Product.model.label("product"),
             Brand.brand.label("brand"),
             extract("week", ProductCalculation.date).label("week"),
             extract("year", ProductCalculation.date).label("year"),
@@ -23,6 +40,8 @@ def price_stats():
         )
         .group_by(
             Supplier.name,
+            Product.id,
+            Product.model,
             Brand.brand,
             extract("year", ProductCalculation.date),
             extract("week", ProductCalculation.date),
@@ -37,6 +56,8 @@ def price_stats():
     data = [
         {
             "supplier": r.supplier,
+            "product_id": r.product_id,
+            "product": r.product,
             "brand": r.brand,
             "week": f"S{int(r.week):02d}-{int(r.year)}",
             "avg_price": float(r.avg_price),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,14 @@
-import { Calculator, LibraryBig, Palette, Settings } from 'lucide-react';
+import { Calculator, LibraryBig, Palette, Settings, BarChart2 } from 'lucide-react';
 import { useState } from 'react';
 import { fetchApitest } from './api';
 import AdminPage from './components/AdminPage';
 import FormattingPage from './components/FormattingPage';
 import ProcessingPage from './components/ProcessingPage';
 import ProductsPage from './components/ProductsPage';
+import StatisticsPage from './components/StatisticsPage';
 
 function App() {
-  const [currentPage, setCurrentPage] = useState<'processing' | 'formatting' | 'admin' | 'products'>('processing');
+  const [currentPage, setCurrentPage] = useState<'processing' | 'formatting' | 'admin' | 'products' | 'stats'>('processing');
   const [apiTestMessage, setApiTestMessage] = useState<string | null>(null);
 
   const handleApiTest = async () => {
@@ -63,6 +64,17 @@ function App() {
               <span>Produits</span>
             </button>
             <button
+              onClick={() => setCurrentPage('stats')}
+              className={`flex items-center space-x-2 px-6 py-3 rounded-lg font-semibold transition-all duration-200
+                ${currentPage === 'stats'
+                  ? 'bg-[#B8860B] text-black'
+                  : 'bg-zinc-800 text-white hover:bg-zinc-700'
+                }`}
+            >
+              <BarChart2 className="w-5 h-5" />
+              <span>Stats</span>
+            </button>
+            <button
               onClick={() => setCurrentPage('admin')}
               className={`flex items-center space-x-2 px-6 py-3 rounded-lg font-semibold transition-all duration-200
                   ${currentPage === 'admin'
@@ -89,6 +101,9 @@ function App() {
       )}
       {currentPage === 'products' && (
         <ProductsPage onBack={() => setCurrentPage('processing')} />
+      )}
+      {currentPage === 'stats' && (
+        <StatisticsPage onBack={() => setCurrentPage('processing')} />
       )}
       {currentPage !== 'admin' && (
         <div className="text-center mt-8 mb-6">

--- a/src/api.ts
+++ b/src/api.ts
@@ -245,8 +245,17 @@ export async function fetchDeviceTypes() {
   return res.json();
 }
 
-export async function fetchPriceStats() {
-  const res = await fetch(`${API_BASE}/price_stats`);
+export async function fetchPriceStats(params?: {
+  supplierId?: number;
+  brandId?: number;
+  productId?: number;
+}) {
+  const search = new URLSearchParams();
+  if (params?.supplierId) search.set('supplier_id', String(params.supplierId));
+  if (params?.brandId) search.set('brand_id', String(params.brandId));
+  if (params?.productId) search.set('product_id', String(params.productId));
+  const query = search.toString();
+  const res = await fetch(`${API_BASE}/price_stats${query ? `?${query}` : ''}`);
   if (!res.ok) {
     throw new Error('Erreur lors du chargement des statistiques');
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -249,11 +249,15 @@ export async function fetchPriceStats(params?: {
   supplierId?: number;
   brandId?: number;
   productId?: number;
+  startWeek?: string;
+  endWeek?: string;
 }) {
   const search = new URLSearchParams();
   if (params?.supplierId) search.set('supplier_id', String(params.supplierId));
   if (params?.brandId) search.set('brand_id', String(params.brandId));
   if (params?.productId) search.set('product_id', String(params.productId));
+  if (params?.startWeek) search.set('start_week', params.startWeek);
+  if (params?.endWeek) search.set('end_week', params.endWeek);
   const query = search.toString();
   const res = await fetch(`${API_BASE}/price_stats${query ? `?${query}` : ''}`);
   if (!res.ok) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -244,3 +244,11 @@ export async function fetchDeviceTypes() {
   }
   return res.json();
 }
+
+export async function fetchPriceStats() {
+  const res = await fetch(`${API_BASE}/price_stats`);
+  if (!res.ok) {
+    throw new Error('Erreur lors du chargement des statistiques');
+  }
+  return res.json();
+}

--- a/src/components/StatisticsPage.tsx
+++ b/src/components/StatisticsPage.tsx
@@ -8,9 +8,7 @@ import {
 } from '../api';
 
 interface PriceStat {
-  supplier: string;
-  product: string;
-  brand: string;
+  supplier?: string;
   week: string;
   avg_price: number;
 }
@@ -25,7 +23,12 @@ interface ProductItem {
   brand_id: number | null;
 }
 
-function LineChart({ data }: { data: { label: string; value: number }[] }) {
+interface Point {
+  label: string;
+  value: number;
+}
+
+function LineChart({ data }: { data: Point[] }) {
   const width = 700;
   const height = 320;
   const padding = 40;
@@ -52,7 +55,6 @@ function LineChart({ data }: { data: { label: string; value: number }[] }) {
 
   return (
     <svg width={width} height={height} className="bg-zinc-900 rounded">
-      {/* grid */}
       {Array.from({ length: ticks + 1 }).map((_, i) => (
         <line
           key={i}
@@ -63,48 +65,18 @@ function LineChart({ data }: { data: { label: string; value: number }[] }) {
           stroke="#333"
         />
       ))}
-      {/* axes */}
-      <line
-        x1={padding}
-        y1={height - padding}
-        x2={width - padding}
-        y2={height - padding}
-        stroke="white"
-      />
-      <line
-        x1={padding}
-        y1={padding}
-        x2={padding}
-        y2={height - padding}
-        stroke="white"
-      />
-      {/* labels */}
+      <line x1={padding} y1={height - padding} x2={width - padding} y2={height - padding} stroke="white" />
+      <line x1={padding} y1={padding} x2={padding} y2={height - padding} stroke="white" />
       {data.map((d, i) => (
-        <text
-          key={d.label}
-          x={padding + i * stepX}
-          y={height - padding + 15}
-          fontSize="10"
-          textAnchor="middle"
-          fill="white"
-        >
+        <text key={d.label} x={padding + i * stepX} y={height - padding + 15} fontSize="10" textAnchor="middle" fill="white">
           {d.label}
         </text>
       ))}
-      {/* Y-axis labels */}
       {Array.from({ length: ticks + 1 }).map((_, i) => (
-        <text
-          key={i}
-          x={padding - 5}
-          y={height - padding - i * stepY + 4}
-          fontSize="10"
-          textAnchor="end"
-          fill="white"
-        >
+        <text key={i} x={padding - 5} y={height - padding - i * stepY + 4} fontSize="10" textAnchor="end" fill="white">
           {((maxVal / ticks) * i).toFixed(0)}
         </text>
       ))}
-      {/* line */}
       <path d={path} fill="none" stroke="orange" strokeWidth="2" />
       {points.map((p, i) => (
         <circle key={i} cx={p.x} cy={p.y} r={3} fill="orange" />
@@ -113,8 +85,68 @@ function LineChart({ data }: { data: { label: string; value: number }[] }) {
   );
 }
 
+function MultiLineChart({ series }: { series: { name: string; data: Point[] }[] }) {
+  const width = 700;
+  const height = 320;
+  const padding = 40;
+  const all = series.flatMap((s) => s.data);
+
+  if (!all.length) {
+    return <svg width={width} height={height} />;
+  }
+
+  const maxVal = Math.max(...all.map((d) => d.value)) * 1.1;
+  const labels = Array.from(new Set(all.map((d) => d.label))).sort();
+  const stepX = (width - padding * 2) / Math.max(1, labels.length - 1);
+  const ticks = 4;
+  const stepY = (height - padding * 2) / ticks;
+  const colors = ['#f97316', '#38bdf8', '#22c55e', '#e879f9', '#facc15', '#f43f5e'];
+
+  const seriesPaths = series.map((s, idx) => {
+    const pts = labels.map((l) => {
+      const found = s.data.find((d) => d.label === l);
+      return {
+        x: padding + labels.indexOf(l) * stepX,
+        y: found ? height - padding - (found.value / maxVal) * (height - padding * 2) : null,
+      };
+    });
+    const valid = pts.filter((p) => p.y !== null) as { x: number; y: number }[];
+    const path = valid.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+    return { name: s.name, color: colors[idx % colors.length], points: valid, path };
+  });
+
+  return (
+    <svg width={width} height={height} className="bg-zinc-900 rounded">
+      {Array.from({ length: ticks + 1 }).map((_, i) => (
+        <line key={i} x1={padding} y1={height - padding - i * stepY} x2={width - padding} y2={height - padding - i * stepY} stroke="#333" />
+      ))}
+      <line x1={padding} y1={height - padding} x2={width - padding} y2={height - padding} stroke="white" />
+      <line x1={padding} y1={padding} x2={padding} y2={height - padding} stroke="white" />
+      {labels.map((l, i) => (
+        <text key={l} x={padding + i * stepX} y={height - padding + 15} fontSize="10" textAnchor="middle" fill="white">
+          {l}
+        </text>
+      ))}
+      {Array.from({ length: ticks + 1 }).map((_, i) => (
+        <text key={i} x={padding - 5} y={height - padding - i * stepY + 4} fontSize="10" textAnchor="end" fill="white">
+          {((maxVal / ticks) * i).toFixed(0)}
+        </text>
+      ))}
+      {seriesPaths.map((s) => (
+        <g key={s.name}>
+          <path d={s.path} fill="none" stroke={s.color} strokeWidth="2" />
+          {s.points.map((p, i) => (
+            <circle key={i} cx={p.x} cy={p.y} r={3} fill={s.color} />
+          ))}
+        </g>
+      ))}
+    </svg>
+  );
+}
+
 function StatisticsPage({ onBack }: StatisticsPageProps) {
-  const [stats, setStats] = useState<PriceStat[]>([]);
+  const [globalStats, setGlobalStats] = useState<PriceStat[]>([]);
+  const [productStats, setProductStats] = useState<PriceStat[]>([]);
   const [suppliers, setSuppliers] = useState<any[]>([]);
   const [brands, setBrands] = useState<any[]>([]);
   const [products, setProducts] = useState<ProductItem[]>([]);
@@ -122,6 +154,8 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
   const [supplierId, setSupplierId] = useState<number | ''>('');
   const [brandId, setBrandId] = useState<number | ''>('');
   const [productId, setProductId] = useState<number | ''>('');
+  const [startWeek, setStartWeek] = useState('');
+  const [endWeek, setEndWeek] = useState('');
 
   useEffect(() => {
     fetchSuppliers().then((s) => setSuppliers(s as any[])).catch(() => setSuppliers([]));
@@ -129,31 +163,66 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
     fetchProducts().then((p) => setProducts(p as ProductItem[])).catch(() => setProducts([]));
   }, []);
 
-  const loadStats = useCallback(() => {
+  const toApiWeek = (val: string) => {
+    if (!val) return undefined;
+    const [year, week] = val.split('-W');
+    return `S${week}-${year}`;
+  };
+
+  const loadGlobal = useCallback(() => {
     fetchPriceStats({
       supplierId: supplierId ? Number(supplierId) : undefined,
       brandId: brandId ? Number(brandId) : undefined,
-      productId: productId ? Number(productId) : undefined,
+      startWeek: toApiWeek(startWeek),
+      endWeek: toApiWeek(endWeek),
     })
-      .then((res) => setStats(res as PriceStat[]))
-      .catch(() => setStats([]));
-  }, [supplierId, brandId, productId]);
+      .then((res) => setGlobalStats(res as PriceStat[]))
+      .catch(() => setGlobalStats([]));
+  }, [supplierId, brandId, startWeek, endWeek]);
+
+  const loadProduct = useCallback(() => {
+    if (!productId) {
+      setProductStats([]);
+      return;
+    }
+    fetchPriceStats({
+      productId: Number(productId),
+      startWeek: toApiWeek(startWeek),
+      endWeek: toApiWeek(endWeek),
+    })
+      .then((res) => setProductStats(res as PriceStat[]))
+      .catch(() => setProductStats([]));
+  }, [productId, startWeek, endWeek]);
 
   useEffect(() => {
-    loadStats();
-  }, [loadStats]);
+    loadGlobal();
+  }, [loadGlobal]);
+
+  useEffect(() => {
+    loadProduct();
+  }, [loadProduct]);
 
   const filteredProducts = useMemo(
-    () =>
-      products.filter((p) =>
-        brandId ? p.brand_id === Number(brandId) : true
-      ),
+    () => products.filter((p) => (brandId ? p.brand_id === Number(brandId) : true)),
     [products, brandId]
   );
 
-  const chartData = stats
+  const globalData = globalStats
     .sort((a, b) => a.week.localeCompare(b.week))
     .map((f) => ({ label: f.week, value: f.avg_price }));
+
+  const productSeries = useMemo(() => {
+    const map: Record<string, Point[]> = {};
+    productStats.forEach((s) => {
+      if (!s.supplier) return;
+      if (!map[s.supplier]) map[s.supplier] = [];
+      map[s.supplier].push({ label: s.week, value: s.avg_price });
+    });
+    return Object.entries(map).map(([name, data]) => ({
+      name,
+      data: data.sort((a, b) => a.label.localeCompare(b.label)),
+    }));
+  }, [productStats]);
 
   return (
     <div className="max-w-7xl mx-auto px-1 sm:px-2 py-6 sm:py-8">
@@ -165,7 +234,7 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
         <span>Retour</span>
       </button>
       <h1 className="text-2xl font-bold text-center mb-4">Statistiques de prix</h1>
-      <div className="flex flex-wrap gap-4 mb-6">
+      <div className="flex flex-wrap gap-4 mb-6 items-end">
         <select
           value={supplierId}
           onChange={(e) => setSupplierId(e.target.value ? Number(e.target.value) : '')}
@@ -190,12 +259,24 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
             </option>
           ))}
         </select>
+        <input
+          type="week"
+          value={startWeek}
+          onChange={(e) => setStartWeek(e.target.value)}
+          className="bg-zinc-900 border border-zinc-600 rounded px-2 py-1"
+        />
+        <input
+          type="week"
+          value={endWeek}
+          onChange={(e) => setEndWeek(e.target.value)}
+          className="bg-zinc-900 border border-zinc-600 rounded px-2 py-1"
+        />
         <select
           value={productId}
           onChange={(e) => setProductId(e.target.value ? Number(e.target.value) : '')}
           className="bg-zinc-900 border border-zinc-600 rounded px-2 py-1"
         >
-          <option value="">Tous produits</option>
+          <option value="">Choisir un produit</option>
           {filteredProducts.map((p) => (
             <option key={p.id} value={p.id}>
               {p.model}
@@ -203,8 +284,15 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
           ))}
         </select>
       </div>
-      <div className="overflow-auto">
-        <LineChart data={chartData} />
+      <div className="overflow-auto space-y-8">
+        <div>
+          <h2 className="font-semibold mb-2">Vue globale</h2>
+          <LineChart data={globalData} />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Évolution du produit</h2>
+          <MultiLineChart series={productSeries} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/StatisticsPage.tsx
+++ b/src/components/StatisticsPage.tsx
@@ -1,0 +1,159 @@
+import { ArrowLeft } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { fetchPriceStats } from '../api';
+
+interface PriceStat {
+  supplier: string;
+  brand: string;
+  week: string;
+  avg_price: number;
+}
+
+interface StatisticsPageProps {
+  onBack: () => void;
+}
+
+function LineChart({ data }: { data: { label: string; value: number }[] }) {
+  const width = 600;
+  const height = 300;
+  const padding = 40;
+
+  if (!data.length) {
+    return <svg width={width} height={height} />;
+  }
+
+  const maxVal = Math.max(...data.map((d) => d.value)) * 1.1;
+  const stepX = (width - padding * 2) / Math.max(1, data.length - 1);
+
+  const points = data.map((d, i) => {
+    const x = padding + i * stepX;
+    const y = height - padding - (d.value / maxVal) * (height - padding * 2);
+    return { x, y };
+  });
+
+  const path = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`)
+    .join(' ');
+
+  return (
+    <svg width={width} height={height} className="bg-zinc-900 rounded">
+      {/* axes */}
+      <line
+        x1={padding}
+        y1={height - padding}
+        x2={width - padding}
+        y2={height - padding}
+        stroke="white"
+      />
+      <line
+        x1={padding}
+        y1={padding}
+        x2={padding}
+        y2={height - padding}
+        stroke="white"
+      />
+      {/* labels */}
+      {data.map((d, i) => (
+        <text
+          key={d.label}
+          x={padding + i * stepX}
+          y={height - padding + 15}
+          fontSize="10"
+          textAnchor="middle"
+          fill="white"
+        >
+          {d.label}
+        </text>
+      ))}
+      {/* line */}
+      <path d={path} fill="none" stroke="#B8860B" strokeWidth="2" />
+      {points.map((p, i) => (
+        <circle key={i} cx={p.x} cy={p.y} r={3} fill="#B8860B" />
+      ))}
+    </svg>
+  );
+}
+
+function StatisticsPage({ onBack }: StatisticsPageProps) {
+  const [stats, setStats] = useState<PriceStat[]>([]);
+  const [supplier, setSupplier] = useState('');
+  const [brand, setBrand] = useState('');
+
+  useEffect(() => {
+    fetchPriceStats()
+      .then((res) => {
+        setStats(res as PriceStat[]);
+      })
+      .catch(() => setStats([]));
+  }, []);
+
+  const suppliers = useMemo(
+    () => Array.from(new Set(stats.map((s) => s.supplier))).sort(),
+    [stats]
+  );
+  const brands = useMemo(
+    () => Array.from(new Set(stats.map((s) => s.brand))).sort(),
+    [stats]
+  );
+
+  useEffect(() => {
+    if (!supplier && suppliers.length) {
+      setSupplier(suppliers[0]);
+    }
+  }, [supplier, suppliers]);
+
+  useEffect(() => {
+    if (!brand && brands.length) {
+      setBrand(brands[0]);
+    }
+  }, [brand, brands]);
+
+  const filtered = stats
+    .filter((s) => (supplier ? s.supplier === supplier : true))
+    .filter((s) => (brand ? s.brand === brand : true))
+    .sort((a, b) => a.week.localeCompare(b.week));
+
+  const chartData = filtered.map((f) => ({ label: f.week, value: f.avg_price }));
+
+  return (
+    <div className="max-w-7xl mx-auto px-1 sm:px-2 py-6 sm:py-8">
+      <button
+        onClick={onBack}
+        className="flex items-center space-x-2 px-4 py-2 bg-zinc-800 text-white rounded-lg hover:bg-zinc-700 transition-colors mb-6"
+      >
+        <ArrowLeft className="w-5 h-5" />
+        <span>Retour</span>
+      </button>
+      <h1 className="text-2xl font-bold text-center mb-4">Statistiques de prix</h1>
+      <div className="flex flex-wrap gap-4 mb-6">
+        <select
+          value={supplier}
+          onChange={(e) => setSupplier(e.target.value)}
+          className="bg-zinc-900 border border-zinc-600 rounded px-2 py-1"
+        >
+          {suppliers.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <select
+          value={brand}
+          onChange={(e) => setBrand(e.target.value)}
+          className="bg-zinc-900 border border-zinc-600 rounded px-2 py-1"
+        >
+          {brands.map((b) => (
+            <option key={b} value={b}>
+              {b}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="overflow-auto">
+        <LineChart data={chartData} />
+      </div>
+    </div>
+  );
+}
+
+export default StatisticsPage;


### PR DESCRIPTION
## Summary
- add `/price_stats` endpoint with weekly aggregation
- hook up new API route via blueprint
- provide StatisticsPage with a basic SVG line chart
- link stats page from navigation menu
- expose `fetchPriceStats` helper in `api.ts`
- document statistics in README

## Testing
- `pytest`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68749718040c83278611bb790b543845