### PR TITLE
Fix statistics chart weeks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Application complète de gestion de tarifs avec système de panier et commande p
 - Graphiques dynamiques par semaine avec filtres fournisseur, marque et intervalle de semaines
 - Comparaison de l'évolution d'un produit selon les fournisseurs
 - Visualisations avancées : évolution relative, distribution des prix, écart-type, min/max, indice, corrélations et détection d'anomalies
+- Bouton d'information (i) expliquant chaque graphique
+- Filtre pour choisir les graphiques visibles, enregistré en base
 
 ## Configuration EmailJS
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AJT PRO - Système de Tarification avec Panier
 
-Application complète de gestion de tarifs avec système de panier et commande par email.
+Application de gestion des couts par fournisseurs et définition des prix de ventes
 
 ## Fonctionnalités
 
-### 🔧 Étape 1 - Traitement des données
+### 🔧 Traitement des données
 - Import de fichiers Excel **(validée)**
 - Calculs automatiques (TCP, marges) **(validée)**
 - Filtrage par marques **(validée)**
@@ -13,17 +13,12 @@ Application complète de gestion de tarifs avec système de panier et commande p
 - Export des données traitées **(validée)**
 - Rapprochement automatique avec les références **(validée)**
 
-### 🎨 Étape 2 - Mise en forme
+### 🎨 Mise en forme
+- A partir de la page produits ajout **(pas fait)**
 - Génération de fichiers Excel formatés **(pas fait)**
 - Création de pages web de consultation client **(pas fait)**
 - Interface moderne avec design professionnel **(pas fait)**
 - Publication en ligne **(pas fait)**
-
-### 🛒 Système de panier
-- Sélection de produits avec quantités **(pas fait)**
-- Gestion complète du panier **(pas fait)**
-- Formulaire de commande client **(pas fait)**
-- Envoi automatique par email **(pas fait)**
 
 ### ⚙️ Administration
 - Interface d'administration intuitive **(validée)**
@@ -41,33 +36,6 @@ Application complète de gestion de tarifs avec système de panier et commande p
 - Visualisations avancées : évolution relative, distribution des prix, écart-type, min/max, indice, corrélations et détection d'anomalies
 - Bouton d'information (i) expliquant chaque graphique
 - Filtre pour choisir les graphiques visibles, enregistré en base
-
-## Configuration EmailJS
-
-Pour activer l'envoi d'emails, configurez EmailJS :
-
-1. Créez un compte sur [EmailJS](https://www.emailjs.com/)
-2. Créez un service email
-3. Créez un template avec les variables suivantes :
-   - `{{customer_name}}`
-   - `{{customer_email}}`
-   - `{{customer_phone}}`
-   - `{{customer_company}}`
-   - `{{customer_address}}`
-   - `{{order_details}}`
-   - `{{total_amount}}`
-   - `{{order_date}}`
-   - `{{total_items}}`
-   - `{{order_id}}`
-   - `{{brands_summary}}`
-
-4. Remplacez les valeurs dans `src/services/emailService.ts` :
-   const EMAIL_CONFIG = {
-    serviceId: 'VOTRE_SERVICE_ID',
-    templateId: 'VOTRE_TEMPLATE_ID',
-    publicKey: 'VOTRE_PUBLIC_KEY'
-  };
-  ```
 
 ## Fichier `.env`
 
@@ -87,7 +55,6 @@ Ce fichier est ignoré par Git afin de protéger vos informations sensibles.
 - **Tailwind CSS** pour le design
 - **Lucide React** pour les icônes
 - **XLSX** pour la manipulation Excel
-- **EmailJS** pour l'envoi d'emails
 - **Context API** pour la gestion d'état
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Application complète de gestion de tarifs avec système de panier et commande p
 ### 📊 Statistiques
 - Graphiques dynamiques par semaine avec filtres fournisseur, marque et intervalle de semaines
 - Comparaison de l'évolution d'un produit selon les fournisseurs
+- Visualisations avancées : évolution relative, distribution des prix, écart-type, min/max, indice, corrélations et détection d'anomalies
 
 ## Configuration EmailJS
 

--- a/backend/implement_tables.py
+++ b/backend/implement_tables.py
@@ -79,6 +79,10 @@ cur.execute(
     "INSERT INTO exclusions (term) VALUES ('Mac'), ('Backbone'), ('Bulk'), ('OH25B'), ('Soundbar');"
 )
 
+cur.execute(
+    "INSERT INTO graph_settings (name, visible) VALUES ('global', True),('product', False),('relative', False),('distribution', False),('stdev', False),('range', False),('index', False),('correlation', False),('anomalies', False);"
+)
+
 conn.commit()
 cur.close()
 conn.close()

--- a/backend/models.py
+++ b/backend/models.py
@@ -181,3 +181,11 @@ class ImportHistory(db.Model):
     )
     product_count = db.Column(db.Integer, nullable=False)
     import_date = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+
+class GraphSetting(db.Model):
+    __tablename__ = "graph_settings"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), unique=True, nullable=False)
+    visible = db.Column(db.Boolean, nullable=False, default=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -187,5 +187,5 @@ class GraphSetting(db.Model):
     __tablename__ = "graph_settings"
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(50), unique=True, nullable=False)
-    visible = db.Column(db.Boolean, nullable=False, default=True)
+    name = db.Column(db.String(50), unique=True, nullable=True)
+    visible = db.Column(db.Boolean, nullable=True, default=True)

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,4 +1,4 @@
-from . import imports, products, references, main, stats
+from . import imports, products, references, main, stats, settings
 
 
 def register_routes(app):
@@ -7,3 +7,4 @@ def register_routes(app):
     app.register_blueprint(products.bp)
     app.register_blueprint(references.bp)
     app.register_blueprint(stats.bp)
+    app.register_blueprint(settings.bp)

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -3,10 +3,12 @@ from models import GraphSetting, db
 
 bp = Blueprint("settings", __name__)
 
+
 @bp.route("/graph_settings", methods=["GET"])
 def list_graph_settings():
     settings = GraphSetting.query.all()
     return jsonify([{"name": s.name, "visible": s.visible} for s in settings])
+
 
 @bp.route("/graph_settings/<name>", methods=["PUT"])
 def update_graph_setting(name):

--- a/backend/routes/settings.py
+++ b/backend/routes/settings.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, jsonify, request
+from models import GraphSetting, db
+
+bp = Blueprint("settings", __name__)
+
+@bp.route("/graph_settings", methods=["GET"])
+def list_graph_settings():
+    settings = GraphSetting.query.all()
+    return jsonify([{"name": s.name, "visible": s.visible} for s in settings])
+
+@bp.route("/graph_settings/<name>", methods=["PUT"])
+def update_graph_setting(name):
+    data = request.json or {}
+    visible = bool(data.get("visible", False))
+    setting = GraphSetting.query.filter_by(name=name).first()
+    if setting:
+        setting.visible = visible
+    else:
+        setting = GraphSetting(name=name, visible=visible)
+        db.session.add(setting)
+    db.session.commit()
+    return jsonify({"status": "success"})

--- a/backend/utils/calculations.py
+++ b/backend/utils/calculations.py
@@ -84,7 +84,7 @@ def recalculate_product_calculations():
             query = query.filter(Product.memory_id == temp.memory_id)
         if temp.color_id is not None:
             query = query.filter(Product.color_id == temp.color_id)
-        if temp.model_id is not None:
+        if temp.model is not None:
             query = query.filter(Product.model.ilike(f"%{temp.model}%"))
         product = query.first()
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -265,3 +265,23 @@ export async function fetchPriceStats(params?: {
   }
   return res.json();
 }
+
+export async function fetchGraphSettings() {
+  const res = await fetch(`${API_BASE}/graph_settings`);
+  if (!res.ok) {
+    throw new Error('Erreur lors du chargement des préférences');
+  }
+  return res.json();
+}
+
+export async function updateGraphSetting(name: string, visible: boolean) {
+  const res = await fetch(`${API_BASE}/graph_settings/${name}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ visible })
+  });
+  if (!res.ok) {
+    throw new Error('Erreur lors de la mise à jour');
+  }
+  return res.json();
+}

--- a/src/components/InfoButton.tsx
+++ b/src/components/InfoButton.tsx
@@ -1,0 +1,28 @@
+import { Info } from 'lucide-react';
+import { useState } from 'react';
+
+interface InfoButtonProps {
+  text: string;
+}
+
+function InfoButton({ text }: InfoButtonProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <span className="relative inline-block ml-1 align-middle">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="text-zinc-400 hover:text-white"
+      >
+        <Info className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="absolute left-5 top-0 z-10 w-60 text-xs bg-zinc-800 border border-zinc-600 rounded p-2">
+          {text}
+        </div>
+      )}
+    </span>
+  );
+}
+
+export default InfoButton;

--- a/src/components/StatisticsPage.tsx
+++ b/src/components/StatisticsPage.tsx
@@ -9,6 +9,7 @@ import {
 
 interface PriceStat {
   supplier?: string;
+  brand?: string;
   week: string;
   avg_price: number;
 }
@@ -207,9 +208,20 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
     [products, brandId]
   );
 
-  const globalData = globalStats
-    .sort((a, b) => a.week.localeCompare(b.week))
-    .map((f) => ({ label: f.week, value: f.avg_price }));
+  const globalData = useMemo(() => {
+    const map: Record<string, { sum: number; count: number }> = {};
+    globalStats.forEach((s) => {
+      if (!map[s.week]) {
+        map[s.week] = { sum: s.avg_price, count: 1 };
+      } else {
+        map[s.week].sum += s.avg_price;
+        map[s.week].count += 1;
+      }
+    });
+    return Object.entries(map)
+      .map(([week, { sum, count }]) => ({ label: week, value: sum / count }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [globalStats]);
 
   const productSeries = useMemo(() => {
     const map: Record<string, Point[]> = {};

--- a/src/components/StatisticsPage.tsx
+++ b/src/components/StatisticsPage.tsx
@@ -35,7 +35,12 @@ function LineChart({ data }: { data: Point[] }) {
   const padding = 40;
 
   if (!data.length) {
-    return <svg width={width} height={height} />;
+    return (
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full h-80 bg-zinc-900 rounded"
+      />
+    );
   }
 
   const maxVal = Math.max(...data.map((d) => d.value)) * 1.1;
@@ -55,7 +60,11 @@ function LineChart({ data }: { data: Point[] }) {
   const stepY = (height - padding * 2) / ticks;
 
   return (
-    <svg width={width} height={height} className="bg-zinc-900 rounded">
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-80 bg-zinc-900 rounded"
+      preserveAspectRatio="xMidYMid meet"
+    >
       {Array.from({ length: ticks + 1 }).map((_, i) => (
         <line
           key={i}
@@ -93,7 +102,12 @@ function MultiLineChart({ series }: { series: { name: string; data: Point[] }[] 
   const all = series.flatMap((s) => s.data);
 
   if (!all.length) {
-    return <svg width={width} height={height} />;
+    return (
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full h-80 bg-zinc-900 rounded"
+      />
+    );
   }
 
   const maxVal = Math.max(...all.map((d) => d.value)) * 1.1;
@@ -117,7 +131,11 @@ function MultiLineChart({ series }: { series: { name: string; data: Point[] }[] 
   });
 
   return (
-    <svg width={width} height={height} className="bg-zinc-900 rounded">
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-80 bg-zinc-900 rounded"
+      preserveAspectRatio="xMidYMid meet"
+    >
       {Array.from({ length: ticks + 1 }).map((_, i) => (
         <line key={i} x1={padding} y1={height - padding - i * stepY} x2={width - padding} y2={height - padding - i * stepY} stroke="#333" />
       ))}
@@ -296,14 +314,24 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
           ))}
         </select>
       </div>
-      <div className="overflow-auto space-y-8">
+      <div className="overflow-x-auto space-y-8">
         <div>
           <h2 className="font-semibold mb-2">Vue globale</h2>
           <LineChart data={globalData} />
+          {globalData.length === 0 && (
+            <p className="text-center text-sm text-zinc-400 mt-2">
+              {brandId ? 'Pas de données pour cette marque' : 'Pas de données'}
+            </p>
+          )}
         </div>
         <div>
           <h2 className="font-semibold mb-2">Évolution du produit</h2>
           <MultiLineChart series={productSeries} />
+          {productId && productSeries.length === 0 && (
+            <p className="text-center text-sm text-zinc-400 mt-2">
+              Pas de données pour ce produit
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/StatisticsPage.tsx
+++ b/src/components/StatisticsPage.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeft } from 'lucide-react';
+import InfoButton from './InfoButton';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   fetchPriceStats,
@@ -564,7 +565,7 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
       </div>
       <div className="overflow-x-auto space-y-8">
         <div>
-          <h2 className="font-semibold mb-2">Vue globale</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Vue globale<InfoButton text="Prix moyen toutes marques et fournisseurs pour chaque semaine." /></h2>
           <LineChart data={globalData} />
           {globalData.length === 0 && (
             <p className="text-center text-sm text-zinc-400 mt-2">
@@ -573,7 +574,7 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
           )}
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Évolution du produit</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Évolution du produit<InfoButton text="Comparer l'évolution du prix du produit selon les fournisseurs." /></h2>
           <MultiLineChart series={productSeries} />
           {productId && productSeries.length === 0 && (
             <p className="text-center text-sm text-zinc-400 mt-2">
@@ -582,31 +583,31 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
           )}
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Évolution relative (%)</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Évolution relative (%)<InfoButton text="Variation en pourcentage d'une semaine sur l'autre." /></h2>
           <LineChart data={relativeData} />
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Distribution des prix</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Distribution des prix<InfoButton text="Répartition des prix moyens pour identifier les valeurs atypiques." /></h2>
           <BarChart data={distributionData} />
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Écart-type par fournisseur</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Écart-type par fournisseur<InfoButton text="Mesure la dispersion des prix pour chaque fournisseur." /></h2>
           <BarChart data={stdevData} />
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Prix min/max par semaine</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Prix min/max par semaine<InfoButton text="Fourchette des prix observés chaque semaine." /></h2>
           <RangeChart data={rangeData} />
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Indice des prix (base 100)</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Indice des prix (base 100)<InfoButton text="Indice basé sur la première semaine pour suivre l'évolution globale." /></h2>
           <LineChart data={priceIndexData} />
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Corrélation des prix</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Corrélation des prix<InfoButton text="Met en évidence les fournisseurs ayant des évolutions similaires." /></h2>
           <Heatmap labels={correlationMatrix.labels} matrix={correlationMatrix.matrix} />
         </div>
         <div>
-          <h2 className="font-semibold mb-2">Anomalies détectées</h2>
+          <h2 className="font-semibold mb-2 flex items-center">Anomalies détectées<InfoButton text="Signale les variations supérieures à 20\u00a0% d'une semaine sur l'autre." /></h2>
           {anomalies.length ? (
             <table className="w-full text-sm text-center">
               <thead>

--- a/src/components/StatisticsPage.tsx
+++ b/src/components/StatisticsPage.tsx
@@ -163,6 +163,153 @@ function MultiLineChart({ series }: { series: { name: string; data: Point[] }[] 
   );
 }
 
+function BarChart({ data }: { data: Point[] }) {
+  const width = 700;
+  const height = 320;
+  const padding = 40;
+
+  if (!data.length) {
+    return (
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full h-80 bg-zinc-900 rounded"
+      />
+    );
+  }
+
+  const maxVal = Math.max(...data.map((d) => d.value)) * 1.1;
+  const stepX = (width - padding * 2) / data.length;
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-80 bg-zinc-900 rounded"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {data.map((d, i) => {
+        const x = padding + i * stepX;
+        const barH = (d.value / maxVal) * (height - padding * 2);
+        return (
+          <g key={d.label}>
+            <rect
+              x={x + 5}
+              y={height - padding - barH}
+              width={stepX - 10}
+              height={barH}
+              fill="#f97316"
+            />
+            <text
+              x={x + stepX / 2}
+              y={height - padding + 15}
+              fontSize="10"
+              textAnchor="middle"
+              fill="white"
+            >
+              {d.label}
+            </text>
+          </g>
+        );
+      })}
+      {Array.from({ length: 4 + 1 }).map((_, i) => (
+        <text
+          key={i}
+          x={padding - 5}
+          y={height - padding - ((height - padding * 2) / 4) * i + 4}
+          fontSize="10"
+          textAnchor="end"
+          fill="white"
+        >
+          {((maxVal / 4) * i).toFixed(0)}
+        </text>
+      ))}
+      <line x1={padding} y1={height - padding} x2={width - padding} y2={height - padding} stroke="white" />
+      <line x1={padding} y1={padding} x2={padding} y2={height - padding} stroke="white" />
+    </svg>
+  );
+}
+
+function RangeChart({ data }: { data: { label: string; min: number; max: number }[] }) {
+  const width = 700;
+  const height = 320;
+  const padding = 40;
+
+  if (!data.length) {
+    return (
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="w-full h-80 bg-zinc-900 rounded"
+      />
+    );
+  }
+
+  const maxVal = Math.max(...data.map((d) => d.max)) * 1.1;
+  const stepX = (width - padding * 2) / Math.max(1, data.length - 1);
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className="w-full h-80 bg-zinc-900 rounded"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {data.map((d, i) => {
+        const x = padding + i * stepX;
+        const yMin = height - padding - (d.min / maxVal) * (height - padding * 2);
+        const yMax = height - padding - (d.max / maxVal) * (height - padding * 2);
+        return (
+          <g key={d.label}>
+            <line x1={x} y1={yMin} x2={x} y2={yMax} stroke="#38bdf8" strokeWidth="4" />
+            <text x={x} y={height - padding + 15} fontSize="10" textAnchor="middle" fill="white">
+              {d.label}
+            </text>
+          </g>
+        );
+      })}
+      <line x1={padding} y1={height - padding} x2={width - padding} y2={height - padding} stroke="white" />
+      <line x1={padding} y1={padding} x2={padding} y2={height - padding} stroke="white" />
+    </svg>
+  );
+}
+
+function Heatmap({ labels, matrix }: { labels: string[]; matrix: number[][] }) {
+  if (!labels.length) {
+    return <div className="h-40" />;
+  }
+
+  const color = (v: number) => {
+    const t = Math.max(-1, Math.min(1, v));
+    const r = Math.round(255 * (t < 0 ? 1 : 1 - t));
+    const g = Math.round(255 * (t > 0 ? 1 : 1 + t));
+    return `rgb(${r},${g},150)`;
+  };
+
+  return (
+    <table className="border-collapse">
+      <thead>
+        <tr>
+          <th className="w-20" />
+          {labels.map((l) => (
+            <th key={l} className="text-xs px-2">
+              {l}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {labels.map((row, i) => (
+          <tr key={row}>
+            <th className="text-xs pr-2 text-right">{row}</th>
+            {labels.map((col, j) => (
+              <td key={col} style={{ backgroundColor: color(matrix[i][j]) }} className="w-10 h-6 text-center text-xs">
+                {matrix[i][j].toFixed(2)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
 function StatisticsPage({ onBack }: StatisticsPageProps) {
   const [globalStats, setGlobalStats] = useState<PriceStat[]>([]);
   const [productStats, setProductStats] = useState<PriceStat[]>([]);
@@ -254,6 +401,107 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
     }));
   }, [productStats]);
 
+  const relativeData = useMemo(() => {
+    const sorted = globalData.slice().sort((a, b) => a.label.localeCompare(b.label));
+    return sorted.map((cur, i) => {
+      if (i === 0) return { label: cur.label, value: 0 };
+      const prev = sorted[i - 1].value;
+      const pct = prev ? ((cur.value - prev) / prev) * 100 : 0;
+      return { label: cur.label, value: pct };
+    });
+  }, [globalData]);
+
+  const distributionData = useMemo(() => {
+    if (!globalStats.length) return [] as Point[];
+    const values = globalStats.map((s) => s.avg_price);
+    const bins = 10;
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const step = (max - min) / bins || 1;
+    const result: Point[] = [];
+    for (let i = 0; i < bins; i++) {
+      const start = min + i * step;
+      const end = start + step;
+      const count = values.filter((v) => v >= start && v < end).length;
+      result.push({ label: `${(start).toFixed(0)}-${(end).toFixed(0)}`, value: count });
+    }
+    return result;
+  }, [globalStats]);
+
+  const stdevData = useMemo(() => {
+    const map: Record<string, number[]> = {};
+    productStats.forEach((s) => {
+      if (!s.supplier) return;
+      if (!map[s.supplier]) map[s.supplier] = [];
+      map[s.supplier].push(s.avg_price);
+    });
+    const calc = (arr: number[]) => {
+      const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+      const variance = arr.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / arr.length;
+      return Math.sqrt(variance);
+    };
+    return Object.entries(map).map(([name, arr]) => ({ label: name, value: calc(arr) }));
+  }, [productStats]);
+
+  const rangeData = useMemo(() => {
+    const map: Record<string, { min: number; max: number }> = {};
+    productStats.forEach((s) => {
+      if (!map[s.week]) map[s.week] = { min: s.avg_price, max: s.avg_price };
+      else {
+        map[s.week].min = Math.min(map[s.week].min, s.avg_price);
+        map[s.week].max = Math.max(map[s.week].max, s.avg_price);
+      }
+    });
+    return Object.entries(map)
+      .map(([week, { min, max }]) => ({ label: week, min, max }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [productStats]);
+
+  const priceIndexData = useMemo(() => {
+    if (!globalData.length) return [] as Point[];
+    const base = globalData[0].value || 1;
+    return globalData.map((d) => ({ label: d.label, value: (d.value / base) * 100 }));
+  }, [globalData]);
+
+  const correlationMatrix = useMemo(() => {
+    const suppliersNames = Array.from(new Set(productStats.map((p) => p.supplier).filter(Boolean))) as string[];
+    const weeks = Array.from(new Set(productStats.map((p) => p.week))).sort();
+    const bySupplier: Record<string, (number | null)[]> = {};
+    suppliersNames.forEach((s) => {
+      bySupplier[s] = weeks.map((w) => {
+        const rec = productStats.find((p) => p.supplier === s && p.week === w);
+        return rec ? rec.avg_price : null;
+      });
+    });
+    const corr = (a: (number | null)[], b: (number | null)[]) => {
+      const pairs = a.map((v, i) => [v, b[i]] as [number | null, number | null]).filter((p) => p[0] !== null && p[1] !== null) as [number, number][];
+      const n = pairs.length;
+      if (n < 2) return 0;
+      const mean1 = pairs.reduce((s, [x]) => s + x, 0) / n;
+      const mean2 = pairs.reduce((s, [, y]) => s + y, 0) / n;
+      const num = pairs.reduce((s, [x, y]) => s + (x - mean1) * (y - mean2), 0);
+      const den1 = Math.sqrt(pairs.reduce((s, [x]) => s + Math.pow(x - mean1, 2), 0));
+      const den2 = Math.sqrt(pairs.reduce((s, [, y]) => s + Math.pow(y - mean2, 2), 0));
+      const den = den1 * den2;
+      return den ? num / den : 0;
+    };
+    const matrix = suppliersNames.map((s1) => suppliersNames.map((s2) => corr(bySupplier[s1], bySupplier[s2])));
+    return { labels: suppliersNames, matrix };
+  }, [productStats]);
+
+  const anomalies = useMemo(() => {
+    const sorted = globalData.slice().sort((a, b) => a.label.localeCompare(b.label));
+    const arr: { week: string; change: number }[] = [];
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1].value;
+      const curr = sorted[i].value;
+      if (prev && Math.abs((curr - prev) / prev) >= 0.2) {
+        arr.push({ week: sorted[i].label, change: ((curr - prev) / prev) * 100 });
+      }
+    }
+    return arr;
+  }, [globalData]);
+
   return (
     <div className="max-w-7xl mx-auto px-1 sm:px-2 py-6 sm:py-8">
       <button
@@ -331,6 +579,53 @@ function StatisticsPage({ onBack }: StatisticsPageProps) {
             <p className="text-center text-sm text-zinc-400 mt-2">
               Pas de données pour ce produit
             </p>
+          )}
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Évolution relative (%)</h2>
+          <LineChart data={relativeData} />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Distribution des prix</h2>
+          <BarChart data={distributionData} />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Écart-type par fournisseur</h2>
+          <BarChart data={stdevData} />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Prix min/max par semaine</h2>
+          <RangeChart data={rangeData} />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Indice des prix (base 100)</h2>
+          <LineChart data={priceIndexData} />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Corrélation des prix</h2>
+          <Heatmap labels={correlationMatrix.labels} matrix={correlationMatrix.matrix} />
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Anomalies détectées</h2>
+          {anomalies.length ? (
+            <table className="w-full text-sm text-center">
+              <thead>
+                <tr>
+                  <th>Semaine</th>
+                  <th>Variation %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {anomalies.map((a) => (
+                  <tr key={a.week} className="bg-zinc-800">
+                    <td>{a.week}</td>
+                    <td className="text-red-400">{a.change.toFixed(1)}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <p className="text-center text-sm text-zinc-400">Aucune anomalie</p>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- include brand field in price statistics interface
- aggregate global stats per week so the line chart shows unique weeks

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6874d66a554c8327bcab63de6dfacadb