### PR TITLE
Fix TCP update after memory option changes

### DIFF
--- a/backend/routes/references.py
+++ b/backend/routes/references.py
@@ -10,6 +10,7 @@ from models import (
     Supplier,
     db,
 )
+from utils.calculations import update_product_calculations_for_memory_option
 
 bp = Blueprint("references", __name__)
 
@@ -133,6 +134,8 @@ def update_reference_item(table, item_id):
         _update_products_for_color_translation(
             [old_source, item.color_source], item.color_target_id
         )
+    if table == "memory_options" and "tcp_value" in data:
+        update_product_calculations_for_memory_option(item.id)
     return jsonify({"status": "success"})
 
 


### PR DESCRIPTION
## Summary
- add helper to recalc product calculations for a memory option
- trigger recalculation when updating memory options via reference routes

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6875002bf4688327ad2e5b83e7b6e1c2