### PR TITLE
Fix EAN parsing when importing

### DIFF
--- a/backend/routes/imports.py
+++ b/backend/routes/imports.py
@@ -139,6 +139,9 @@ def create_import():
 
     for _, row in df.iterrows():
         ean_raw = row.get("ean")
+        if isinstance(ean_raw, pd.Series):
+            ean_raw = ean_raw.iloc[0]
+
         if pd.isna(ean_raw) or str(ean_raw).strip() == "":
             ean_value = str(uuid.uuid4())
         else:


### PR DESCRIPTION
## Summary
- fix ambiguous pandas boolean when reading the EAN column

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6875f3c092408327b648a372e46aa9c6