### PR TITLE
Fix API base variable for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     build:
       context: .
       dockerfile: ./frontend/Dockerfile
+      args:
+        VITE_API_BASE: http://localhost:5001
     container_name: ajt_frontend
     ports:
       - "3000:80"
@@ -52,7 +54,7 @@ services:
       - app-network
     restart: unless-stopped
     environment:
-      - REACT_APP_API_URL=http://localhost:5001
+      - VITE_API_BASE=http://localhost:5001
 
   # Service optionnel pour le développement
   frontend-dev:
@@ -70,8 +72,7 @@ services:
     networks:
       - app-network
     environment:
-      - REACT_APP_API_URL=http://localhost:5001
-      - VITE_API_URL=http://localhost:5001
+      - VITE_API_BASE=http://localhost:5001
     profiles:
       - dev
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,6 +6,10 @@ WORKDIR /app
 # Installer les dépendances système pour le diagnostic
 RUN apk add --no-cache tree
 
+# Variable de build pour l'URL de l'API
+ARG VITE_API_BASE
+ENV VITE_API_BASE=${VITE_API_BASE}
+
 # Copier les fichiers package
 COPY frontend/package*.json ./
 
@@ -58,52 +62,9 @@ RUN adduser -S nextjs -u 1001
 RUN chown -R nextjs:nodejs /usr/share/nginx/html
 RUN chown -R nextjs:nodejs /var/cache/nginx
 RUN chown -R nextjs:nodejs /var/log/nginx
-RUN chown -# Étape 1 : Build React
-FROM node:20-alpine AS builder
-
-WORKDIR /app
-
-# Copier les fichiers package pour profiter du cache Docker
-COPY frontend/package*.json ./
-
-# Installer les dépendances (toutes les dépendances pour pouvoir build)
-RUN npm install
-
-# Copier le code source
-COPY frontend/ .
-
-# Build de l'application
-RUN npm run build
-
-# Étape 2 : Serve statique avec NGINX
-FROM nginx:stable-alpine
-
-# Supprimer le site par défaut de nginx
-RUN rm -rf /usr/share/nginx/html/*
-
-# Copier le build React vers nginx
-COPY --from=builder /app/build /usr/share/nginx/html
-
-# Copier la config nginx personnalisée
-COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
-
-# Créer un utilisateur non-root pour la sécurité
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nextjs -u 1001
-
-# Changer les permissions
-RUN chown -R nextjs:nodejs /usr/share/nginx/html
-RUN chown -R nextjs:nodejs /var/cache/nginx
-RUN chown -R nextjs:nodejs /var/log/nginx
 RUN chown -R nextjs:nodejs /etc/nginx/conf.d
 RUN touch /var/run/nginx.pid
 RUN chown -R nextjs:nodejs /var/run/nginx.pid
-
-USER nextjs
-
-EXPOSE 80
-
-CMD ["nginx", "-g", "daemon off;"]R nextjs:nodejs /var/run/nginx.pid
 
 USER nextjs
 


### PR DESCRIPTION
## Summary
- set `VITE_API_BASE` during docker builds
- clean duplicated lines in frontend Dockerfile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest` *(fails to run due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687755a52edc8327a654b626f837b398