### PR TITLE
Allow duplicate column orders

### DIFF
--- a/backend/implement_tables.py
+++ b/backend/implement_tables.py
@@ -53,11 +53,11 @@ def main():
         # Insérer les formats d'import
         cur.execute(
             """
-            INSERT INTO format_imports (supplier_id, column_name, column_type, column_order) VALUES 
-            (1, 'description', 'string', 2), 
-            (1, 'model', 'string', 2), 
-            (1, 'quantity', 'number', 3), 
-            (1, 'sellingprice', 'number', 4), 
+            INSERT INTO format_imports (supplier_id, column_name, column_type, column_order) VALUES
+            (1, 'description', 'string', 2),
+            (1, 'model', 'string', 2),
+            (1, 'quantity', 'number', 3),
+            (1, 'sellingprice', 'number', 4),
             (1, 'ean', 'number', 7);
         """
         )

--- a/backend/routes/imports.py
+++ b/backend/routes/imports.py
@@ -125,28 +125,14 @@ def create_import():
                 400,
             )
 
-    by_order = {}
-    duplicate_orders = []
+    # Map Excel columns to standardized names. Duplicate column_order values
+    # are allowed and will copy data from the same source column.
     for m in mappings:
-        if m.column_order is None:
+        if m.column_order is None or not m.column_name:
             continue
         idx = m.column_order - 1
-        if idx in by_order:
-            duplicate_orders.append(m.column_order)
-        else:
-            by_order[idx] = (m.column_name or "").lower()
-    if duplicate_orders:
-        current_app.logger.error(
-            f"Duplicated column_order values for supplier {supplier_id}: {duplicate_orders}"
-        )
-        return (
-            jsonify({"error": "Duplicate column orders found for this supplier."}),
-            400,
-        )
-
-    for idx, col in enumerate(list(df.columns)):
-        if idx in by_order:
-            df.rename(columns={col: by_order[idx]}, inplace=True)
+        if 0 <= idx < len(df.columns):
+            df[(m.column_name or "").lower()] = df.iloc[:, idx]
 
 
     required_columns = [

--- a/backend/routes/imports.py
+++ b/backend/routes/imports.py
@@ -134,7 +134,6 @@ def create_import():
         if 0 <= idx < len(df.columns):
             df[(m.column_name or "").lower()] = df.iloc[:, idx]
 
-
     required_columns = [
         (m.column_name or "").lower() for m in mappings if m.column_name
     ]


### PR DESCRIPTION
## Summary
- adjust sample `format_imports` data to allow duplicates
- copy Excel columns for every mapping to support duplicate `column_order` values

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68779bf4c8ec8327bcb168798465de3a