### PR TITLE
Add import invalid rows report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ backend/alembic/*
 **/*.pyc
 
 todo.md
+backend/log
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ L'application expose notamment les routes :
 - `POST /upload` : envoi d'un fichier Excel pour importer plusieurs produits.
 - `POST /import` : importe un fichier Excel dans `temp_imports` et crée les références
   correspondantes.
+- `POST /import_preview` : renvoie un aperçu des 5 premières lignes valides avant import.
 - `GET /product_calculations/count` : renvoie le nombre de résultats de calcul disponibles.
 
 Dans l'application React, le fichier traité est automatiquement transmis au backend via l'endpoint `/upload`. L'import du référentiel utilise quant à lui l'endpoint `/import`.

--- a/backend/implement_tables.py
+++ b/backend/implement_tables.py
@@ -57,7 +57,7 @@ def main():
             (1, 'description', 2),
             (1, 'model', 2),
             (1, 'quantity', 3),
-            (1, 'sellingprice', 4),
+            (1, 'selling_price', 4),
             (1, 'ean', 7);
         """
         )

--- a/backend/implement_tables.py
+++ b/backend/implement_tables.py
@@ -53,12 +53,12 @@ def main():
         # Insérer les formats d'import
         cur.execute(
             """
-            INSERT INTO format_imports (supplier_id, column_name, column_type, column_order) VALUES
-            (1, 'description', 'string', 2),
-            (1, 'model', 'string', 2),
-            (1, 'quantity', 'number', 3),
-            (1, 'sellingprice', 'number', 4),
-            (1, 'ean', 'number', 7);
+            INSERT INTO format_imports (supplier_id, column_name, column_order) VALUES
+            (1, 'description', 2),
+            (1, 'model', 2),
+            (1, 'quantity', 3),
+            (1, 'sellingprice', 4),
+            (1, 'ean', 7);
         """
         )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -192,7 +192,6 @@ class FormatImport(db.Model):
         "Supplier", backref=db.backref("format_imports", lazy=True)
     )
     column_name = db.Column(db.String(50), nullable=True)
-    column_type = db.Column(db.String(50), nullable=True)
     column_order = db.Column(db.Integer, nullable=True)
 
 

--- a/backend/routes/references.py
+++ b/backend/routes/references.py
@@ -97,7 +97,6 @@ def get_reference_table(table):
                 "id": obj.id,
                 "supplier_id": obj.supplier_id,
                 "column_name": obj.column_name,
-                "column_type": obj.column_type,
                 "column_order": obj.column_order,
             }
         return {}


### PR DESCRIPTION
## Summary
- create a backend log file when importing products
- record line number, description and cause for each invalid row

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877a1244e6c832790ccf99f356219b3