### PR TITLE
Fix average price calculation

### DIFF
--- a/frontend/src/components/ProductsPage.tsx
+++ b/frontend/src/components/ProductsPage.tsx
@@ -13,6 +13,7 @@ import {
   fetchDeviceTypes,
   fetchMemoryOptions,
 } from '../api';
+import { parsePrice } from '../utils/numbers';
 
 interface ProductCalculation {
   [key: string]: string | number | null;
@@ -95,7 +96,7 @@ function ProductsPage({ onBack }: ProductsPageProps) {
           const pid = item.product_id as number;
           const supplier = (item.supplier as string) || '';
           if (supplier) suppliersSet.add(supplier);
-          const prix = Number(item.prixht_max);
+          const prix = parsePrice(item.prixht_max);
           if (!map.has(pid)) {
             map.set(pid, {
               id: pid,
@@ -131,7 +132,9 @@ function ProductsPage({ onBack }: ProductsPageProps) {
             memory: val.memory,
             color: val.color,
             type: val.type,
-            averagePrice: val.count ? val.sum / val.count : 0,
+            averagePrice: val.count
+              ? Number((val.sum / val.count).toFixed(2))
+              : 0,
             supplierPrices: val.prices,
           });
         });

--- a/frontend/src/utils/numbers.ts
+++ b/frontend/src/utils/numbers.ts
@@ -1,0 +1,18 @@
+export function parsePrice(value: any): number {
+  if (value === undefined || value === null) return NaN;
+  let str = String(value).trim();
+  // remove spaces and currency symbols
+  str = str.replace(/[^0-9.,-]/g, '');
+  str = str.replace(/\s+/g, '');
+  if (str.includes(',') && str.includes('.')) {
+    if (str.lastIndexOf('.') < str.lastIndexOf(',')) {
+      str = str.replace(/\./g, '').replace(',', '.');
+    } else {
+      str = str.replace(/,/g, '');
+    }
+  } else {
+    str = str.replace(',', '.');
+  }
+  const num = parseFloat(str);
+  return Number.isNaN(num) ? NaN : num;
+}


### PR DESCRIPTION
## Summary
- fix parsing of price values by introducing `parsePrice`
- use `parsePrice` in `ProductsPage` and round calculated averages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877db53653c83279e680af575d765de