### PR TITLE
Improve preview modal behaviour

### DIFF
--- a/frontend/src/components/ImportPreviewModal.tsx
+++ b/frontend/src/components/ImportPreviewModal.tsx
@@ -13,10 +13,10 @@ function ImportPreviewModal({ rows, onClose }: ImportPreviewModalProps) {
   const headers = rows.length > 0 ? Object.keys(rows[0]) : [];
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
-      <div className="bg-zinc-900 p-6 rounded-lg border border-zinc-700 max-w-2xl w-full">
+      <div className="bg-zinc-900 p-6 rounded-lg border border-zinc-700 max-w-4xl w-5/6">
         <h2 className="text-xl font-semibold mb-4">Prévisualisation de l'import</h2>
         {rows.length > 0 ? (
-          <div className="overflow-auto max-h-96 mb-4">
+          <div className="overflow-auto max-h-[60vh] mb-4">
             <table className="table">
               <thead>
                 <tr>

--- a/frontend/src/components/ProcessingPage.tsx
+++ b/frontend/src/components/ProcessingPage.tsx
@@ -67,7 +67,6 @@ function ImportZone({ supplier, file, lastImportDate, onFileChange }: ImportZone
         droppedFile?.type === 'application/vnd.ms-excel'
       ) {
         onFileChange(supplier.id, droppedFile);
-        previewFile(droppedFile);
       }
     },
     [supplier.id, onFileChange]
@@ -78,7 +77,6 @@ function ImportZone({ supplier, file, lastImportDate, onFileChange }: ImportZone
       const selectedFile = e.target.files?.[0];
       if (selectedFile) {
         onFileChange(supplier.id, selectedFile);
-        previewFile(selectedFile);
       }
     },
     [supplier.id, onFileChange]


### PR DESCRIPTION
## Summary
- only show preview modal when clicking the **Prévisualiser** button
- widen the preview modal and limit table height

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f25a35e8832787037276c8f96658