### PR TITLE
Fix front notifications for backend errors

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,12 @@ import { getCurrentTimestamp } from './utils/date';
 
 export const API_BASE = import.meta.env.VITE_API_BASE || '';
 
+
+async function extractErrorMessage(res: Response): Promise<string> {
+  const data = await res.json().catch(() => ({}));
+  return data.message || data.error || 'Une erreur est survenue';
+}
+
 export async function fetchApitest() {
   const res = await fetch(`${API_BASE}/`);
   if (!res.ok) {
@@ -23,8 +29,7 @@ export async function createImport(file: File, supplierId?: number) {
     body: formData
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -41,8 +46,7 @@ export async function fetchImportPreview(file: File, supplierId?: number) {
     body: formData
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -50,8 +54,7 @@ export async function fetchImportPreview(file: File, supplierId?: number) {
 export async function fetchProducts() {
   const res = await fetch(`${API_BASE}/products`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -63,8 +66,7 @@ export async function createProduct(data: any) {
     body: JSON.stringify(data)
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -76,8 +78,7 @@ export async function updateProduct(id: number, data: any) {
     body: JSON.stringify(data)
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -89,8 +90,7 @@ export async function bulkUpdateProducts(data: any[]) {
     body: JSON.stringify(data)
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -100,8 +100,7 @@ export async function deleteProduct(id: number) {
     method: 'DELETE'
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -110,8 +109,7 @@ export async function deleteProduct(id: number) {
 export async function fetchLastImport(id: number): Promise<{ import_date: string | null } | {}> {
   const res = await fetch(`${API_BASE}/last_import/${id}`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -119,8 +117,7 @@ export async function fetchLastImport(id: number): Promise<{ import_date: string
 export async function verifyImport(id: number) {
   const res = await fetch(`${API_BASE}/verify_import/${id}`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -132,8 +129,7 @@ export async function calculateProducts() {
     headers: { 'Content-Type': 'application/json' },
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -158,8 +154,7 @@ export async function exportCalculations() {
 export async function fetchSuppliers() {
   const res = await fetch(`${API_BASE}/references/suppliers`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -170,8 +165,7 @@ export async function refreshProduction() {
     headers: { 'Content-Type': 'application/json' },
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -184,8 +178,7 @@ export async function refreshProductionByWeek(array_date: Array<Date>) {
     body: JSON.stringify({ dates: array_date.map(date => date.toISOString()) })
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -193,8 +186,7 @@ export async function refreshProductionByWeek(array_date: Array<Date>) {
 export async function fetchProductCalculations() {
   const res = await fetch(`${API_BASE}/product_calculation`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -202,8 +194,7 @@ export async function fetchProductCalculations() {
 export async function fetchProductPriceSummary() {
   const res = await fetch(`${API_BASE}/product_price_summary`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -211,8 +202,7 @@ export async function fetchProductPriceSummary() {
 export async function fetchReferenceTable(table: string) {
   const res = await fetch(`${API_BASE}/references/${table}`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -224,8 +214,7 @@ export async function updateReferenceItem(table: string, id: number, data: any) 
     body: JSON.stringify(data)
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -237,8 +226,7 @@ export async function createReferenceItem(table: string, data: any) {
     body: JSON.stringify(data)
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -250,8 +238,7 @@ export async function deleteReferenceItem(table: string, id: number) {
     method: 'DELETE'
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -259,8 +246,7 @@ export async function deleteReferenceItem(table: string, id: number) {
 export async function fetchBrands() {
   const res = await fetch(`${API_BASE}/references/brands`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -269,8 +255,7 @@ export async function fetchBrands() {
 export async function fetchColors() {
   const res = await fetch(`${API_BASE}/references/colors`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -278,8 +263,7 @@ export async function fetchColors() {
 export async function fetchMemoryOptions() {
   const res = await fetch(`${API_BASE}/references/memory_options`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -287,8 +271,7 @@ export async function fetchMemoryOptions() {
 export async function fetchDeviceTypes() {
   const res = await fetch(`${API_BASE}/references/device_types`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -309,8 +292,7 @@ export async function fetchPriceStats(params?: {
   const query = search.toString();
   const res = await fetch(`${API_BASE}/price_stats${query ? `?${query}` : ''}`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -331,8 +313,7 @@ export async function fetchBrandSupplierAverage(params?: {
     `${API_BASE}/brand_supplier_average${query ? `?${query}` : ''}`
   );
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -355,8 +336,7 @@ export async function fetchProductSupplierAverage(params?: {
     `${API_BASE}/product_supplier_average${query ? `?${query}` : ''}`
   );
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -364,8 +344,7 @@ export async function fetchProductSupplierAverage(params?: {
 export async function fetchGraphSettings() {
   const res = await fetch(`${API_BASE}/graph_settings`);
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }
@@ -377,8 +356,7 @@ export async function updateGraphSetting(name: string, visible: boolean) {
     body: JSON.stringify({ visible })
   });
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({}));
-    throw new Error(errorData.message);
+    throw new Error(await extractErrorMessage(res));
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- handle API error messages consistently

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687a5ed3e8008327aa220bf03c57dc6b