### PR TITLE
Fix refresh_week ImportHistory date field

### DIFF
--- a/backend/routes/products.py
+++ b/backend/routes/products.py
@@ -306,8 +306,8 @@ def refresh_week():
             ProductCalculation.date < end,
         ).delete(synchronize_session=False)
         ImportHistory.query.filter(
-            ImportHistory.date >= start,
-            ImportHistory.date < end,
+            ImportHistory.import_date >= start,
+            ImportHistory.import_date < end,
         ).delete(synchronize_session=False)
 
     db.session.commit()


### PR DESCRIPTION
## Summary
- fix ImportHistory query in refresh_week() to use `import_date`

## Testing
- `python3 -m py_compile backend/routes/products.py`

------
https://chatgpt.com/codex/tasks/task_e_687ab63598148327846d2d7ef70efe88