### PR TITLE
Add JWT secret env and compose mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ FLASK_DEBUG=1
 POSTGRES_DB=ajtpro
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
+
+# JWT
+JWT_SECRET=change-me

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       PYTHONPATH: /app
       FRONTEND_URL: http://localhost:5173,http://localhost:3000
       CORS_ORIGINS: "http://localhost:3000,http://localhost:5173,http://frontend:80,http://frontend-dev:5173"
+      JWT_SECRET: ${JWT_SECRET}
     volumes:
       - ./backend:/app
     container_name: ajt_backend


### PR DESCRIPTION
## Summary
- document JWT secret in `.env.example`
- pass JWT_SECRET environment variable to backend via docker-compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab636e1788327ad7a96ab5647b2dd