### PR TITLE
Seed admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ make venv         # crée l'environnement virtuel et installe les dépendances
 make run          # démarre l'API Flask
 ```
 
+### Identifiants par défaut
+
+Le script `backend/implement_tables.py` crée automatiquement un utilisateur
+**admin** pour faciliter le développement local.
+
+- **Nom d'utilisateur** : `admin`
+- **Mot de passe** : `admin`
+
 Une documentation interactive est générée grâce à **Flasgger**. Une fois
 l'application lancée, ouvrez `http://localhost:5001/apidocs` pour consulter les
 endpoints disponibles. Le fichier `backend/swagger_template.yml` contient le

--- a/backend/implement_tables.py
+++ b/backend/implement_tables.py
@@ -35,10 +35,23 @@ def main():
         # Nettoyer les tables existantes
         cur.execute(
             """
-            TRUNCATE TABLE suppliers, brands, colors, memory_options, device_types, exclusions, color_translations,graph_settings RESTART IDENTITY CASCADE;
+            TRUNCATE TABLE users, suppliers, brands, colors, memory_options,
+            device_types, exclusions, color_translations, graph_settings
+            RESTART IDENTITY CASCADE;
         """
         )
         conn.commit()
+
+        print("🔐 Création de l'utilisateur administrateur...")
+        from models import User
+
+        admin = User(username="admin", role="admin")
+        admin.set_password("admin")
+
+        cur.execute(
+            "INSERT INTO users (username, password_hash, role) VALUES (%s, %s, %s)",
+            (admin.username, admin.password_hash, admin.role),
+        )
 
         print("👥 Insertion des fournisseurs...")
         # Insérer les fournisseurs
@@ -165,6 +178,7 @@ def main():
         # Afficher un résumé
         print("\n📈 Résumé des données insérées:")
         tables = [
+            ('users', 'Utilisateurs'),
             ('suppliers', 'Fournisseurs'),
             ('brands', 'Marques'),
             ('colors', 'Couleurs'),

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,8 +1,24 @@
 from datetime import datetime
 
 from flask_sqlalchemy import SQLAlchemy
+from werkzeug.security import generate_password_hash, check_password_hash
 
 db = SQLAlchemy()
+
+
+class User(db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(50), nullable=False, default="user")
+
+    def set_password(self, password: str) -> None:
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        return check_password_hash(self.password_hash, password)
 
 
 class Supplier(db.Model):


### PR DESCRIPTION
## Summary
- add a simple `User` model with password hashing helpers
- create admin user in `implement_tables.py`
- include admin credentials in the README

## Testing
- `pytest -q`
- `python -m py_compile backend/models.py backend/implement_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_687ab63815208327ae0aa74fdb8d173a