### PR TITLE
Handle duplicate reference items gracefully

### DIFF
--- a/backend/routes/references.py
+++ b/backend/routes/references.py
@@ -14,6 +14,7 @@ from models import (
     Supplier,
     db,
 )
+from sqlalchemy.exc import IntegrityError
 from utils.calculations import update_product_calculations_for_memory_option
 
 bp = Blueprint("references", __name__)
@@ -149,7 +150,11 @@ def update_reference_item(table, item_id):
     for key, value in data.items():
         if hasattr(item, key):
             setattr(item, key, value)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({"error": "champ existant"}), 400
     if table == "color_translations":
         _update_products_for_color_translation(
             [old_source, item.color_source], item.color_target_id
@@ -186,7 +191,11 @@ def create_reference_item(table):
     data = request.json or {}
     item = model(**data)
     db.session.add(item)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({"error": "champ existant"}), 400
     if table == "color_translations":
         _update_products_for_color_translation(item.color_source, item.color_target_id)
     return jsonify({"id": item.id})

--- a/backend/routes/references.py
+++ b/backend/routes/references.py
@@ -1,5 +1,4 @@
 from flask import Blueprint, jsonify, request
-from utils.auth import token_required
 from models import (
     Brand,
     Color,
@@ -8,13 +7,14 @@ from models import (
     Exclusion,
     FormatImport,
     MemoryOption,
-    RAMOption,
     NormeOption,
     Product,
+    RAMOption,
     Supplier,
     db,
 )
 from sqlalchemy.exc import IntegrityError
+from utils.auth import token_required
 from utils.calculations import update_product_calculations_for_memory_option
 
 bp = Blueprint("references", __name__)
@@ -154,7 +154,7 @@ def update_reference_item(table, item_id):
         db.session.commit()
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "champ existant"}), 400
+        return jsonify({"error": "Données existantes"}), 400
     if table == "color_translations":
         _update_products_for_color_translation(
             [old_source, item.color_source], item.color_target_id
@@ -195,7 +195,7 @@ def create_reference_item(table):
         db.session.commit()
     except IntegrityError:
         db.session.rollback()
-        return jsonify({"error": "champ existant"}), 400
+        return jsonify({"error": "Données existantes"}), 400
     if table == "color_translations":
         _update_products_for_color_translation(item.color_source, item.color_target_id)
     return jsonify({"id": item.id})

--- a/frontend/src/components/ReferenceAdmin.tsx
+++ b/frontend/src/components/ReferenceAdmin.tsx
@@ -75,8 +75,9 @@ function ReferenceAdmin({ isVisible, onClose }: ReferenceAdminProps) {
         notify('Entrée mise à jour', 'success');
       }
       await load(table!);
-    } catch {
-      /* empty */
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erreur';
+      notify(message, 'error');
     }
   };
 


### PR DESCRIPTION
## Summary
- return explicit `champ existant` message when unique constraints are violated in reference creation and update
- surface API errors in reference admin UI

## Testing
- `python -m py_compile backend/routes/references.py`
- `npm --prefix frontend run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'typescript-eslint')*
- `npm --prefix frontend install typescript-eslint --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a2a6f5388327926bf7e354d6ebfd