### PR TITLE
Ensure sale price recalculates from TCP when margins change

### DIFF
--- a/backend/utils/calculations.py
+++ b/backend/utils/calculations.py
@@ -138,7 +138,7 @@ def recalculate_product_calculations():
             prixht_marge4_5=round(price_with_margin, 2),
             prixht_max=max_price,
             date=datetime.now(timezone.utc),
-            marge=round(max_price - tcp, 2),
+            marge=round(max_price - tcp - price, 2),
         )
         db.session.add(calc)
 
@@ -158,7 +158,7 @@ def update_product_calculations_for_memory_option(memory_option_id: int) -> None
     )
 
     for calc in calcs:
-        price = calc.price
+        price = calc.price or 0
         tcp = option.tcp_value
         margin45 = price * 0.045
         price_with_tcp = price + tcp + margin45
@@ -196,7 +196,7 @@ def update_product_calculations_for_memory_option(memory_option_id: int) -> None
         calc.prixht_tcp_marge4_5 = round(price_with_tcp, 2)
         calc.prixht_marge4_5 = round(price_with_margin, 2)
         calc.prixht_max = max_price
-        calc.marge = round(max_price - tcp, 2)
+        calc.marge = round(max_price - tcp - price, 2)
 
     if calcs:
         db.session.commit()


### PR DESCRIPTION
## Summary
- update backend calculations to compute margins as sale price minus TCP and purchase price
- include the minimum buy price, persisted margins, and TCP values in product summaries so sale prices can be recomputed from the stored formula when a margin is edited
- adjust the product list UI to consume the TCP data and recalculate sale prices from TCP + buy price when admins change the margin

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68c82faf01d8832791924fbb57206c44