### PR TITLE
Fix memory options insert with tcp_value

### DIFF
--- a/backend/scripts/database/add_references_import_2025_0923.py
+++ b/backend/scripts/database/add_references_import_2025_0923.py
@@ -59,9 +59,10 @@ def main():
         for memory in memory_values:
             try:
                 cur.execute(
-                    "INSERT INTO memory_options (memory) VALUES (%s)", (memory,)
+                    "INSERT INTO memory_options (memory, tcp_value) VALUES (%s, %s)",
+                    (memory, 0),
                 )
-                print(f"✅ Ajouté Memory: {memory}")
+                print(f"✅ Ajouté Memory: {memory} (tcp_value=0)")
             except psycopg2.IntegrityError:
                 print(f"⚠️  Memory {memory} existe déjà")
                 conn.rollback()  # Rollback pour cette insertion seulement


### PR DESCRIPTION
## Summary
- ensure the memory options seeding script explicitly sets tcp_value to 0 when inserting new rows so it matches the table schema
- update the related log message to reflect the tcp_value default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3730216f88327a313dc73ad74b142