### PR TITLE
Handle integrity errors during reference deletions

### DIFF
--- a/backend/routes/references.py
+++ b/backend/routes/references.py
@@ -227,5 +227,12 @@ def delete_reference_item(table, item_id):
         return jsonify({"error": "Table inconnue"}), 400
     item = model.query.get_or_404(item_id)
     db.session.delete(item)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return (
+            jsonify({"error": "Impossible de supprimer l'élément car il est utilisé"}),
+            400,
+        )
     return jsonify({"status": "deleted"})


### PR DESCRIPTION
## Summary
- add integrity error handling when deleting reference items to return a clear 400 response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d927240c2083279935c7861c54cefa