### PR TITLE
Log reasons for non-imported products during reference import

### DIFF
--- a/backend/scripts/database/import_reference_products.py
+++ b/backend/scripts/database/import_reference_products.py
@@ -9,7 +9,7 @@ import os
 import sys
 import unicodedata
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, Optional, Set
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import psycopg2
 from dotenv import load_dotenv
@@ -21,10 +21,28 @@ from psycopg2.extras import DictCursor
 class ImportStats:
     inserted: int = 0
     updated: int = 0
+    updated_by_ean: int = 0
+    updated_by_model: int = 0
     skipped: int = 0
     errors: int = 0
     missing_references: Dict[str, list[str]] = field(default_factory=dict)
     unresolved_by_name: Dict[str, list[str]] = field(default_factory=dict)
+    update_reasons: Dict[str, list[int]] = field(default_factory=dict)
+    truncations: Dict[int, List["TruncationInfo"]] = field(default_factory=dict)
+    not_imported: Dict[int, "NotImportedInfo"] = field(default_factory=dict)
+
+
+@dataclass
+class TruncationInfo:
+    column: str
+    max_length: int
+    original_length: int
+
+
+@dataclass
+class NotImportedInfo:
+    label: str
+    reason: str
 
 
 COLUMN_MAP: Dict[str, str] = {
@@ -329,16 +347,56 @@ class ReferenceCache:
         )
 
 
+class ProductValueSanitizer:
+    """S'assure que les valeurs texte respectent les contraintes de longueur."""
+
+    def __init__(self, cursor):
+        self.max_lengths = self._load_column_lengths(cursor)
+
+    def _load_column_lengths(self, cursor) -> Dict[str, Optional[int]]:
+        cursor.execute(
+            """
+            SELECT column_name, character_maximum_length
+              FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = 'products'
+            """
+        )
+        lengths: Dict[str, Optional[int]] = {}
+        for row in cursor.fetchall():
+            lengths[row["column_name"]] = row["character_maximum_length"]
+        return lengths
+
+    def sanitize(
+        self, values: Dict[str, Optional[str]]
+    ) -> Tuple[Dict[str, Optional[str]], List[TruncationInfo]]:
+        sanitized = dict(values)
+        truncations: List[TruncationInfo] = []
+        for column, value in values.items():
+            if value is None:
+                continue
+            max_length = self.max_lengths.get(column)
+            if max_length and len(value) > max_length:
+                sanitized[column] = value[:max_length].rstrip()
+                truncations.append(
+                    TruncationInfo(
+                        column=column,
+                        max_length=max_length,
+                        original_length=len(value),
+                    )
+                )
+        return sanitized, truncations
+
+
 def _find_product_id(
     cursor, ean: Optional[str], model: Optional[str], brand_id: Optional[int]
-) -> Optional[int]:
-    """Tenter de retrouver un produit existant."""
+) -> Tuple[Optional[int], Optional[str]]:
+    """Tenter de retrouver un produit existant et indiquer la logique utilisée."""
 
     if ean:
         cursor.execute("SELECT id FROM products WHERE ean = %s", (ean,))
         row = cursor.fetchone()
         if row:
-            return row["id"]
+            return row["id"], "ean"
 
     if model:
         if brand_id:
@@ -346,15 +404,17 @@ def _find_product_id(
                 "SELECT id FROM products WHERE LOWER(model) = LOWER(%s) AND brand_id = %s",
                 (model, brand_id),
             )
+            reason = "model+brand"
         else:
             cursor.execute(
                 "SELECT id FROM products WHERE LOWER(model) = LOWER(%s)",
                 (model,),
             )
+            reason = "model"
         row = cursor.fetchone()
         if row:
-            return row["id"]
-    return None
+            return row["id"], reason
+    return None, None
 
 
 def process_csv(
@@ -383,6 +443,7 @@ def process_csv(
 
         with conn.cursor() as cursor:
             ref_cache = ReferenceCache(cursor, default_tcp=default_tcp)
+            sanitizer = ProductValueSanitizer(cursor)
 
             for index, row in enumerate(
                 reader, start=2
@@ -398,7 +459,12 @@ def process_csv(
                 model = normalized.get("model") or description
 
                 if not description and not model:
+                    product_label = normalized.get("name") or normalized.get("model") or "(inconnu)"
                     stats.skipped += 1
+                    stats.not_imported[index] = NotImportedInfo(
+                        label=product_label,
+                        reason="Nom et modèle absents après nettoyage",
+                    )
                     continue
 
                 name_hint = description or model
@@ -417,7 +483,24 @@ def process_csv(
                 ean = normalized.get("ean")
                 part_number = normalized.get("part_number")
 
-                product_id = _find_product_id(cursor, ean, model, brand_id)
+                sanitized_strings, truncations = sanitizer.sanitize(
+                    {
+                        "description": description,
+                        "model": model,
+                        "ean": ean,
+                        "part_number": part_number,
+                    }
+                )
+                description = sanitized_strings.get("description")
+                model = sanitized_strings.get("model") or description
+                ean = sanitized_strings.get("ean")
+                part_number = sanitized_strings.get("part_number")
+                if truncations:
+                    stats.truncations[index] = truncations
+
+                product_id, match_reason = _find_product_id(
+                    cursor, ean, model, brand_id
+                )
 
                 try:
                     if product_id:
@@ -451,6 +534,12 @@ def process_csv(
                             ),
                         )
                         stats.updated += 1
+                        if match_reason == "ean":
+                            stats.updated_by_ean += 1
+                        elif match_reason in {"model", "model+brand"}:
+                            stats.updated_by_model += 1
+                        if match_reason:
+                            stats.update_reasons.setdefault(match_reason, []).append(index)
                     else:
                         cursor.execute(
                             """
@@ -480,6 +569,11 @@ def process_csv(
                     conn.rollback()
                     stats.errors += 1
                     errors.append(f"Ligne {index}: {exc}")
+                    product_label = description or model or "(inconnu)"
+                    stats.not_imported[index] = NotImportedInfo(
+                        label=product_label,
+                        reason=f"Erreur lors de l'écriture en base: {exc}",
+                    )
 
             if stats.errors:
                 print("\n❌ Des erreurs ont été rencontrées lors de l'import :")
@@ -489,6 +583,10 @@ def process_csv(
             print("\n📊 Résumé de l'import :")
             print(f"   ➕ Produits insérés : {stats.inserted}")
             print(f"   🔁 Produits mis à jour : {stats.updated}")
+            if stats.updated:
+                print(
+                    f"      ↳ dont {stats.updated_by_ean} par EAN et {stats.updated_by_model} par modèle"
+                )
             print(f"   ⏭️  Produits ignorés : {stats.skipped}")
             print(f"   ⚠️  Lignes en erreur : {stats.errors}")
 
@@ -513,6 +611,28 @@ def process_csv(
                     print(f"   - {table} (d'après le nom): {joined}")
             else:
                 print("\n✅ Toutes les références nécessaires ont été trouvées.")
+
+            if stats.update_reasons:
+                print("\nℹ️  Détails des mises à jour :")
+                for reason, lines in stats.update_reasons.items():
+                    joined = ", ".join(str(line) for line in lines)
+                    print(f"   - {reason}: lignes {joined}")
+
+            if stats.truncations:
+                print("\n✂️  Valeurs tronquées pour respecter les contraintes :")
+                for line, infos in sorted(stats.truncations.items()):
+                    details = ", ".join(
+                        f"{info.column} (max {info.max_length}, initiale {info.original_length} caractères)"
+                        for info in infos
+                    )
+                    print(f"   - Ligne {line}: {details}")
+
+            if stats.not_imported:
+                print("\n🚫 Produits non importés :")
+                for line, info in sorted(stats.not_imported.items()):
+                    label = info.label.strip()
+                    display = f" ({label})" if label and label != "(inconnu)" else ""
+                    print(f"   - Ligne {line}{display}: {info.reason}")
 
     return stats
 


### PR DESCRIPTION
## Summary
- track skipped CSV rows as not imported with their product label and reason
- report non-imported products in the import summary alongside truncations and errors

## Testing
- python -m compileall backend/scripts/database/import_reference_products.py

------
https://chatgpt.com/codex/tasks/task_e_68d9266ac69c832786923759ca4a23bb